### PR TITLE
fix(shadow-atlas): national-scale address-index build (parallel downloads + workers + resumable cache)

### DIFF
--- a/.github/workflows/shadow-atlas-quarterly.yml
+++ b/.github/workflows/shadow-atlas-quarterly.yml
@@ -742,7 +742,7 @@ jobs:
   build-address-index:
     name: Build Address Index
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 360
     needs: [generate-cell-chunks]
     steps:
       - name: Checkout code
@@ -764,7 +764,23 @@ jobs:
           name: chunked-with-cell-chunks
           path: packages/shadow-atlas/output/chunked/
 
+      # ADDRFEAT download cache — resume, not restart. County zips are
+      # verified-complete (zip magic + EOCD) before reuse, so a re-run after
+      # a transient census.gov failure skips every finished download instead
+      # of repeating hours of them. The exact key is unique per attempt
+      # (immutable caches can't be updated in place); restore always falls
+      # through to the newest same-vintage prefix. Size fits comfortably:
+      # national ADDRFEAT ≈ 680 MB zipped vs the 10 GB repo cache budget.
+      - name: Restore ADDRFEAT download cache
+        uses: actions/cache/restore@v4
+        with:
+          path: packages/shadow-atlas/data/addrfeat-cache
+          key: addrfeat-${{ inputs.addrfeat_vintage || 'unknown' }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            addrfeat-${{ inputs.addrfeat_vintage || 'unknown' }}-
+
       - name: Build address index (NAD src:0 + ADDRFEAT src:1)
+        id: build-address-index
         working-directory: packages/shadow-atlas
         run: |
           set -euo pipefail
@@ -801,6 +817,16 @@ jobs:
           echo "### Address Index" >> $GITHUB_STEP_SUMMARY
           jq -r '"- **Chunks:** \(.addressIndex.totalChunks)\n- **Streets:** \(.addressIndex.totalStreets)\n- **Points:** \(.addressIndex.totalPoints)\n- **Ranges:** \(.addressIndex.totalRanges)\n- **NAD vintage:** \(.addressIndex.nadVintage)\n- **ADDRFEAT vintage:** \(.addressIndex.addrfeatVintage)"' \
             output/chunked/US/manifest.json >> $GITHUB_STEP_SUMMARY
+
+      # Save even when the build FAILS — that is the whole point: the next
+      # attempt resumes from the completed downloads. (actions/cache's
+      # built-in post-save skips on failure, hence the explicit save step.)
+      - name: Save ADDRFEAT download cache
+        if: always() && steps.build-address-index.outcome != 'skipped'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/shadow-atlas/data/addrfeat-cache
+          key: addrfeat-${{ inputs.addrfeat_vintage || 'unknown' }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Upload chunked output with addresses
         uses: actions/upload-artifact@v4

--- a/packages/shadow-atlas/scripts/build-address-index.ts
+++ b/packages/shadow-atlas/scripts/build-address-index.ts
@@ -5,8 +5,27 @@
  * Ingests two public sources into ZIP5-keyed chunk files:
  *   src:0 — NAD quarterly text release (stream-parsed; NEVER whole-file in
  *           memory — the national file is ~30 GB uncompressed)
- *   src:1 — TIGER ADDRFEAT county files (county-batched download with
- *           retry/resume; each county zip is a few MB)
+ *   src:1 — TIGER ADDRFEAT county files (bounded-parallel download pool +
+ *           forked transform workers; each county zip is a few MB, ~3,200
+ *           counties nationally)
+ *
+ * ADDRFEAT orchestration (national scale — output bytes UNCHANGED):
+ *   - Downloads run through a bounded pool (default 6 concurrent, Census-
+ *     friendly) with exponential backoff + jitter and Retry-After honoring —
+ *     census.gov 'terminate's long sequential bulk fetchers, and one county
+ *     at a time cannot finish 3,200+ counties inside a CI job ceiling.
+ *   - Shapefile→GeoJSON→range transforms run in forked workers (same
+ *     child_process.fork pattern as build-chunked-mapping.ts) so CPU and
+ *     network overlap.
+ *   - Ingestion into the ZIP5 spill store happens IN COUNTY-FIPS ORDER on
+ *     the main process regardless of completion order, so spill contents —
+ *     and therefore every emitted chunk byte — are identical to the old
+ *     sequential loop. This is orchestration only, not a format change.
+ *   - County zips persist in --addrfeat-dir keyed by filename and verified
+ *     complete (zip magic + EOCD) before reuse; a restarted run skips
+ *     verified downloads instead of re-fetching hours of them.
+ *   - Fail-loud: a county that exhausts retries THROWS — a missing county
+ *     must never become a silent geographic hole in the index.
  *
  * Outputs (under <outputDir>, default ./output/chunked):
  *   US/addresses/{zip5}.json        — §2 chunk files
@@ -35,20 +54,20 @@
  * manifest. (Mirrors --tiger-vintage in build-chunked-mapping.ts.)
  */
 
-import { createHash } from 'node:crypto';
+import { fork, type ChildProcess } from 'node:child_process';
 import {
   appendFileSync,
   createReadStream,
-  existsSync,
   mkdirSync,
   readdirSync,
   readFileSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from 'node:fs';
+import { cpus } from 'node:os';
 import { join } from 'node:path';
 import type { Readable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
 
 import { STATE_ABBR_TO_FIPS } from '../src/core/types/fips.js';
 import {
@@ -74,6 +93,11 @@ import {
   type ChunkIndexEntry,
   type ZipAccumulator,
 } from '../src/distribution/addresses/chunk-emit.js';
+import {
+  downloadWithRetry,
+  downloadZipToCache,
+  Semaphore,
+} from '../src/distribution/addresses/download-pool.js';
 import { resolveNadVintage } from '../src/distribution/addresses/nad-vintage.js';
 import { streamNadRows } from '../src/distribution/addresses/nad-stream.js';
 import { resolveTigerVintage } from '../src/distribution/snapshots/tiger-vintage.js';
@@ -91,6 +115,27 @@ interface ParsedArgs {
   states: string[];
   outputDir: string;
   dryRun: boolean;
+  downloadConcurrency: number;
+  transformWorkers: number;
+}
+
+/** Census-friendly ceiling — never point more than this at www2.census.gov. */
+const MAX_DOWNLOAD_CONCURRENCY = 12;
+const MAX_TRANSFORM_WORKERS = 8;
+
+export const DEFAULT_DOWNLOAD_CONCURRENCY = 6;
+export const DEFAULT_TRANSFORM_WORKERS = Math.min(
+  Math.max(1, cpus().length - 1),
+  MAX_TRANSFORM_WORKERS
+);
+
+function parseBoundedInt(raw: string, flag: string, max: number): number {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 1 || n > max) {
+    console.error(`Error: ${flag} must be an integer in [1, ${max}], got '${raw}'`);
+    process.exit(1);
+  }
+  return n;
 }
 
 export function parseArgs(argv: string[]): ParsedArgs {
@@ -101,6 +146,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let states: string[] = [];
   let outputDir = './output/chunked';
   let dryRun = false;
+  let downloadConcurrency = DEFAULT_DOWNLOAD_CONCURRENCY;
+  let transformWorkers = DEFAULT_TRANSFORM_WORKERS;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -129,6 +176,20 @@ export function parseArgs(argv: string[]): ParsedArgs {
       case '--dry-run':
         dryRun = true;
         break;
+      case '--download-concurrency':
+        downloadConcurrency = parseBoundedInt(
+          argv[++i] ?? '',
+          '--download-concurrency',
+          MAX_DOWNLOAD_CONCURRENCY
+        );
+        break;
+      case '--transform-workers':
+        transformWorkers = parseBoundedInt(
+          argv[++i] ?? '',
+          '--transform-workers',
+          MAX_TRANSFORM_WORKERS
+        );
+        break;
       case '--help':
       case '-h':
         printUsage();
@@ -147,7 +208,17 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
   }
 
-  return { nadPath, addrfeatDir, nadVintage, addrfeatVintage, states, outputDir, dryRun };
+  return {
+    nadPath,
+    addrfeatDir,
+    nadVintage,
+    addrfeatVintage,
+    states,
+    outputDir,
+    dryRun,
+    downloadConcurrency,
+    transformWorkers,
+  };
 }
 
 function printUsage(): void {
@@ -169,6 +240,10 @@ Vintages (fail-loud; 'unknown' can never land in a produced manifest):
 Options:
   --states <csv>             Limit to these states (e.g. DE,RI,DC). Default: all.
   --output <path>            Output dir. Default: ./output/chunked
+  --download-concurrency <n> Bounded ADDRFEAT download pool size (1-${MAX_DOWNLOAD_CONCURRENCY}).
+                             Default: ${DEFAULT_DOWNLOAD_CONCURRENCY} (Census-friendly).
+  --transform-workers <n>    Forked shapefile-transform workers (1-${MAX_TRANSFORM_WORKERS}).
+                             Default: min(cpus-1, ${MAX_TRANSFORM_WORKERS}).
   --dry-run                  Print the plan without downloading or writing.
   -h, --help                 Print this message
 `);
@@ -238,7 +313,7 @@ class ZipSpillStore {
 }
 
 // ---------------------------------------------------------------------------
-// Source download helpers (county-batched ADDRFEAT)
+// Source download helpers (pooled ADDRFEAT)
 // ---------------------------------------------------------------------------
 
 interface SourceLogEntry {
@@ -247,28 +322,6 @@ interface SourceLogEntry {
   sha256: string;
   bytes: number;
   reused: boolean;
-}
-
-async function downloadWithRetry(
-  url: string,
-  maxRetries = 4,
-  retryDelayMs = 3_000
-): Promise<Buffer> {
-  let lastError: Error | null = null;
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      return Buffer.from(await response.arrayBuffer());
-    } catch (error) {
-      lastError = error as Error;
-      console.warn(`  download attempt ${attempt}/${maxRetries} failed: ${lastError.message}`);
-      if (attempt < maxRetries) {
-        await new Promise((r) => setTimeout(r, retryDelayMs * attempt));
-      }
-    }
-  }
-  throw new Error(`Download failed after ${maxRetries} attempts: ${url}: ${lastError?.message}`);
 }
 
 /**
@@ -293,44 +346,128 @@ async function listAddrfeatCounties(
   return [...counties].sort();
 }
 
-/**
- * Download one county ADDRFEAT zip with retry/resume: an existing non-empty
- * cached file with a valid zip magic is reused instead of re-fetched.
- */
-async function fetchCountyZip(
-  tigerYear: string,
-  fips5: string,
-  cacheDir: string,
-  sourcesLog: SourceLogEntry[]
-): Promise<Buffer> {
-  const name = `tl_${tigerYear}_${fips5}_addrfeat.zip`;
-  const url = `https://www2.census.gov/geo/tiger/TIGER${tigerYear}/ADDRFEAT/${name}`;
-  const cached = join(cacheDir, name);
+// ---------------------------------------------------------------------------
+// ADDRFEAT transform workers (child_process.fork — same pattern as
+// build-chunked-mapping.ts). A worker receives a cached county zip path,
+// runs shapefile→GeoJSON→range emission, and writes the spill records as
+// NDJSON [zip5, record] lines for the main process to ingest IN COUNTY ORDER.
+// ---------------------------------------------------------------------------
 
-  let buf: Buffer | null = null;
-  let reused = false;
-  if (existsSync(cached) && statSync(cached).size > 4) {
-    const candidate = readFileSync(cached);
-    // Zip local-file-header magic: PK\x03\x04 — guards truncated downloads.
-    if (candidate[0] === 0x50 && candidate[1] === 0x4b) {
-      buf = candidate;
-      reused = true;
+const IS_ADDRFEAT_WORKER = process.env.__ADDRFEAT_WORKER__ === '1';
+
+interface WorkerCountyTask {
+  type: 'county';
+  fips5: string;
+  stateAbbr: string;
+  zipPath: string;
+  outPath: string;
+}
+
+interface WorkerExit {
+  type: 'exit';
+}
+
+interface WorkerCountyDone {
+  type: 'done';
+  fips5: string;
+  outPath: string;
+  edges: number;
+  ranges: number;
+  skipped: number;
+}
+
+interface WorkerCountyError {
+  type: 'error';
+  fips5: string;
+  message: string;
+}
+
+class AddrfeatWorkerPool {
+  private readonly children: ChildProcess[] = [];
+  private readonly idle: ChildProcess[] = [];
+  private readonly waiters: Array<(w: ChildProcess) => void> = [];
+
+  constructor(count: number, workerFile: string) {
+    for (let i = 0; i < count; i++) {
+      const child = fork(workerFile, [], {
+        env: { ...process.env, __ADDRFEAT_WORKER__: '1' },
+      });
+      this.children.push(child);
+      this.idle.push(child);
     }
   }
-  if (!buf) {
-    buf = await downloadWithRetry(url);
-    mkdirSync(cacheDir, { recursive: true });
-    writeFileSync(cached, buf);
+
+  private acquire(): Promise<ChildProcess> {
+    const w = this.idle.pop();
+    if (w) return Promise.resolve(w);
+    return new Promise((resolve) => this.waiters.push(resolve));
   }
 
-  sourcesLog.push({
-    url,
-    file: name,
-    sha256: createHash('sha256').update(buf).digest('hex'),
-    bytes: buf.length,
-    reused,
-  });
-  return buf;
+  private release(w: ChildProcess): void {
+    const waiter = this.waiters.shift();
+    if (waiter) waiter(w);
+    else this.idle.push(w);
+  }
+
+  /** Run one county on the next free worker. Fail-loud: transform errors and
+   *  worker deaths reject — they surface at the ordered-ingest await. */
+  async run(task: Omit<WorkerCountyTask, 'type'>): Promise<WorkerCountyDone> {
+    const child = await this.acquire();
+    try {
+      return await new Promise<WorkerCountyDone>((resolve, reject) => {
+        const onMessage = (msg: WorkerCountyDone | WorkerCountyError): void => {
+          if (msg.fips5 !== task.fips5) return;
+          cleanup();
+          if (msg.type === 'done') resolve(msg);
+          else reject(new Error(`county ${task.fips5} transform failed: ${msg.message}`));
+        };
+        const onExit = (code: number | null): void => {
+          cleanup();
+          reject(
+            new Error(`ADDRFEAT worker exited (code ${code}) while processing county ${task.fips5}`)
+          );
+        };
+        const cleanup = (): void => {
+          child.off('message', onMessage);
+          child.off('exit', onExit);
+        };
+        child.on('message', onMessage);
+        child.on('exit', onExit);
+        if (!child.connected) {
+          cleanup();
+          reject(new Error(`ADDRFEAT worker not connected for county ${task.fips5}`));
+          return;
+        }
+        try {
+          child.send({ type: 'county', ...task } satisfies WorkerCountyTask);
+        } catch (error) {
+          cleanup();
+          reject(error as Error);
+        }
+      });
+    } finally {
+      this.release(child);
+    }
+  }
+
+  shutdown(): void {
+    for (const child of this.children) {
+      try {
+        child.send({ type: 'exit' } satisfies WorkerExit);
+      } catch {
+        /* already gone */
+      }
+      const killer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }, 5_000);
+      killer.unref();
+      child.once('exit', () => clearTimeout(killer));
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -349,10 +486,16 @@ interface AddrfeatProps {
   PARITYR?: string | null;
 }
 
+/** Minimal spill-write seam — satisfied by ZipSpillStore (main process) and
+ *  by the worker's NDJSON line collector. Same records either way. */
+interface SpillSink {
+  push(zip: string, record: unknown[]): void;
+}
+
 function ingestAddrfeatFeature(
   feature: { properties?: unknown; geometry?: unknown },
   stateAbbr: string,
-  spill: ZipSpillStore,
+  spill: SpillSink,
   counters: { ranges: number; skipped: number }
 ): void {
   const props = (feature.properties ?? {}) as AddrfeatProps;
@@ -439,7 +582,9 @@ async function main(): Promise<void> {
   if (args.dryRun) {
     console.log('\nPlan:');
     console.log('  1. Stream-parse NAD rows (src:0) → ZIP5 spill files');
-    console.log(`  2. County-batched TIGER${tigerYear} ADDRFEAT download (src:1) → range records`);
+    console.log(
+      `  2. Pooled TIGER${tigerYear} ADDRFEAT downloads (src:1, ${args.downloadConcurrency} concurrent) → ${args.transformWorkers} transform workers → range records (ordered ingest)`
+    );
     console.log('  3. Aggregate per ZIP5 → US/addresses/{zip5}.json (5-dp coords, E/O/B parity)');
     console.log('  4. Emit normalization.json (Pub 28 B/C1/C2) + chunk-index.json (sha256/bytes)');
     console.log('  5. MERGE addressIndex*/third clock into US/manifest.json (boundary/officials clocks untouched)');
@@ -490,21 +635,121 @@ async function main(): Promise<void> {
     console.log(`  NAD rows ingested: ${nadRows.toLocaleString()} (skipped ${nadSkipped.toLocaleString()})`);
   }
 
-  // ---- Phase 2: TIGER ADDRFEAT (src:1) — county-batched, always runs ----
+  // ---- Phase 2: TIGER ADDRFEAT (src:1) — pooled downloads + forked
+  //      transform workers, ordered ingest (spill bytes identical to the
+  //      old sequential loop) ----
   const addrfeatCounters = { ranges: 0, skipped: 0 };
   console.log(`\nPhase 2: TIGER${tigerYear} ADDRFEAT county batches…`);
   const counties = await listAddrfeatCounties(tigerYear, stateFipsSet);
-  console.log(`  Counties to ingest: ${counties.length}`);
-  for (const fips5 of counties) {
-    const stateAbbr = FIPS_TO_ABBR[fips5.slice(0, 2)] ?? '??';
-    const zip = await fetchCountyZip(tigerYear, fips5, args.addrfeatDir, sourcesLog);
-    const fc = await transformShapefileToGeoJSON(zip);
-    const before = addrfeatCounters.ranges;
-    for (const feature of fc.features) {
-      ingestAddrfeatFeature(feature, stateAbbr, spill, addrfeatCounters);
+  const totalStates = new Set(counties.map((f) => f.slice(0, 2))).size;
+  console.log(
+    `  Counties to ingest: ${counties.length} across ${totalStates} states | downloads: ${args.downloadConcurrency} | workers: ${args.transformWorkers}`
+  );
+
+  if (counties.length > 0) {
+    const downloadSem = new Semaphore(args.downloadConcurrency);
+    // Lookahead window: bounds downloaded-but-uningested counties so tmp
+    // NDJSON backlog stays small while keeping both pools saturated.
+    const windowSem = new Semaphore(
+      Math.max(args.downloadConcurrency + args.transformWorkers, 32)
+    );
+    const pool = new AddrfeatWorkerPool(args.transformWorkers, fileURLToPath(import.meta.url));
+    const tmpDir = join(args.outputDir, 'US', 'addrfeat.tmp');
+    mkdirSync(tmpDir, { recursive: true });
+    mkdirSync(args.addrfeatDir, { recursive: true });
+    const sourceEntries = new Map<string, SourceLogEntry>();
+
+    const phase2Start = Date.now();
+    try {
+      const countyPromises = counties.map((fips5) => {
+        const p = (async (): Promise<WorkerCountyDone> => {
+          await windowSem.acquire(); // released after this county is ingested
+          const name = `tl_${tigerYear}_${fips5}_addrfeat.zip`;
+          const url = `https://www2.census.gov/geo/tiger/TIGER${tigerYear}/ADDRFEAT/${name}`;
+          const cached = join(args.addrfeatDir, name);
+          const dl = await downloadSem.run(() => downloadZipToCache(url, cached));
+          sourceEntries.set(fips5, {
+            url,
+            file: name,
+            sha256: dl.sha256,
+            bytes: dl.bytes,
+            reused: dl.reused,
+          });
+          return pool.run({
+            fips5,
+            stateAbbr: FIPS_TO_ABBR[fips5.slice(0, 2)] ?? '??',
+            zipPath: cached,
+            outPath: join(tmpDir, `${fips5}.ndjson`),
+          });
+        })();
+        // Mark handled — the ordered-ingest loop below rethrows in county
+        // order, so a failure can never be silently skipped.
+        p.catch(() => {});
+        return p;
+      });
+
+      // Ordered ingest: county-FIPS order regardless of completion order.
+      let stateIdx = 0;
+      let currentStateFips = '';
+      let stateStartMs = 0;
+      let stateCounties = 0;
+      const finishState = (): void => {
+        if (currentStateFips === '') return;
+        const mins = (Date.now() - stateStartMs) / 60_000;
+        const rate = mins > 0 ? (stateCounties / mins).toFixed(1) : '∞';
+        console.log(
+          `  [state ${stateIdx}/${totalStates}] ${FIPS_TO_ABBR[currentStateFips] ?? currentStateFips} done: ${stateCounties} counties in ${mins.toFixed(1)} min (${rate} counties/min)`
+        );
+      };
+
+      for (let i = 0; i < counties.length; i++) {
+        const fips5 = counties[i];
+        const stateFips = fips5.slice(0, 2);
+        const stateAbbr = FIPS_TO_ABBR[stateFips] ?? '??';
+        if (stateFips !== currentStateFips) {
+          finishState();
+          currentStateFips = stateFips;
+          stateIdx++;
+          stateStartMs = Date.now();
+          stateCounties = 0;
+          console.log(
+            `  [state ${stateIdx}/${totalStates}] ${stateAbbr} starting (county ${i + 1}/${counties.length})`
+          );
+        }
+        const done = await countyPromises[i]; // fail-loud: rejection aborts here
+        const raw = readFileSync(done.outPath, 'utf-8');
+        for (const line of raw.split('\n')) {
+          if (line.length === 0) continue;
+          const [zip5, record] = JSON.parse(line) as [string, unknown[]];
+          spill.push(zip5, record);
+        }
+        rmSync(done.outPath, { force: true });
+        addrfeatCounters.ranges += done.ranges;
+        addrfeatCounters.skipped += done.skipped;
+        stateCounties++;
+        windowSem.release();
+        console.log(
+          `  ${fips5} (${stateAbbr}): ${done.edges.toLocaleString()} edges → ${done.ranges.toLocaleString()} ranges`
+        );
+      }
+      finishState();
+    } finally {
+      pool.shutdown();
+      rmSync(tmpDir, { recursive: true, force: true });
     }
+
+    // Sources log in county order — deterministic regardless of download
+    // completion order.
+    for (const fips5 of counties) {
+      const entry = sourceEntries.get(fips5);
+      if (!entry) throw new Error(`missing sources-log entry for county ${fips5}`); // unreachable
+      sourcesLog.push(entry);
+    }
+
+    const phase2Mins = (Date.now() - phase2Start) / 60_000;
+    const overallRate = phase2Mins > 0 ? (counties.length / phase2Mins).toFixed(1) : '∞';
     console.log(
-      `  ${fips5} (${stateAbbr}): ${fc.features.length.toLocaleString()} edges → ${(addrfeatCounters.ranges - before).toLocaleString()} ranges`
+      `  ADDRFEAT throughput: ${counties.length} counties in ${phase2Mins.toFixed(1)} min → ${overallRate} counties/min`
     );
   }
   console.log(
@@ -623,14 +868,59 @@ async function main(): Promise<void> {
   console.log('\nDone.');
 }
 
+// ---------------------------------------------------------------------------
+// Worker process — transforms one county at a time on request
+// ---------------------------------------------------------------------------
+
+function runAddrfeatWorker(): void {
+  process.on('message', (msg: WorkerCountyTask | WorkerExit) => {
+    if (msg.type === 'exit') process.exit(0);
+    if (msg.type !== 'county') return;
+    void (async () => {
+      try {
+        const zip = readFileSync(msg.zipPath);
+        const fc = await transformShapefileToGeoJSON(zip);
+        const counters = { ranges: 0, skipped: 0 };
+        const lines: string[] = [];
+        const sink: SpillSink = {
+          push: (zip5, record) => {
+            lines.push(JSON.stringify([zip5, record]));
+          },
+        };
+        for (const feature of fc.features) {
+          ingestAddrfeatFeature(feature, msg.stateAbbr, sink, counters);
+        }
+        writeFileSync(msg.outPath, lines.length > 0 ? lines.join('\n') + '\n' : '');
+        process.send!({
+          type: 'done',
+          fips5: msg.fips5,
+          outPath: msg.outPath,
+          edges: fc.features.length,
+          ranges: counters.ranges,
+          skipped: counters.skipped,
+        } satisfies WorkerCountyDone);
+      } catch (error) {
+        process.send!({
+          type: 'error',
+          fips5: msg.fips5,
+          message: error instanceof Error ? error.message : String(error),
+        } satisfies WorkerCountyError);
+      }
+    })();
+  });
+}
+
 // Only run main() when invoked as a CLI (mirrors the IS_WORKER guard pattern);
 // unit tests import parseArgs and the emission modules without side effects.
+// A forked child shares argv[1], so the worker check MUST come first.
 const invokedDirectly =
   process.argv[1] !== undefined &&
   (process.argv[1].endsWith('build-address-index.ts') ||
     process.argv[1].endsWith('build-address-index.js'));
 
-if (invokedDirectly) {
+if (IS_ADDRFEAT_WORKER) {
+  runAddrfeatWorker();
+} else if (invokedDirectly) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : error);
     process.exit(1);

--- a/packages/shadow-atlas/src/__tests__/unit/address-index/download-pool.test.ts
+++ b/packages/shadow-atlas/src/__tests__/unit/address-index/download-pool.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Download pool — bounded-parallel census.gov fetch orchestration.
+ *
+ * Verifies the four pool guarantees the national ADDRFEAT build stands on:
+ *   1. bounded concurrency (never more than N fetches in flight)
+ *   2. exponential backoff + jitter between failed attempts, Retry-After honored
+ *   3. fail-loud on retry exhaustion (a missing county must never be a
+ *      silent geographic hole)
+ *   4. verified-complete cache hits skip the network entirely
+ *
+ * All effects are injected — no real network, no real timers.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  downloadWithRetry,
+  downloadZipToCache,
+  isCompleteZipBuffer,
+  parseRetryAfterMs,
+  runBoundedPool,
+  Semaphore,
+} from '../../../distribution/addresses/download-pool.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal verified-complete zip: local-file magic + EOCD record in the tail. */
+function completeZipBuffer(padding = 64): Buffer {
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0); // PK\x05\x06
+  return Buffer.concat([Buffer.from('PK\x03\x04'), Buffer.alloc(padding), eocd]);
+}
+
+/** Truncated download: valid magic, no EOCD — must NOT be treated as cached. */
+function truncatedZipBuffer(): Buffer {
+  return Buffer.concat([Buffer.from('PK\x03\x04'), Buffer.alloc(64)]);
+}
+
+function okResponse(body: Buffer): Response {
+  return new Response(new Uint8Array(body), { status: 200 });
+}
+
+const noSleep = (): Promise<void> => Promise.resolve();
+
+// ---------------------------------------------------------------------------
+// Semaphore + runBoundedPool — bounded concurrency
+// ---------------------------------------------------------------------------
+
+describe('runBoundedPool', () => {
+  it('never exceeds the concurrency bound', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    await runBoundedPool(items, 3, async (i) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 2 + (i % 3)));
+      inFlight--;
+      return i * 2;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(1); // it actually parallelized
+  });
+
+  it('preserves input order in results', async () => {
+    const items = [5, 1, 4, 2, 3];
+    const results = await runBoundedPool(items, 2, async (n) => {
+      await new Promise((r) => setTimeout(r, n)); // finish out of order
+      return n * 10;
+    });
+    expect(results).toEqual([50, 10, 40, 20, 30]);
+  });
+
+  it('fails loud on the first error after in-flight work settles', async () => {
+    const seen: number[] = [];
+    await expect(
+      runBoundedPool([1, 2, 3, 4, 5, 6, 7, 8], 2, async (n) => {
+        seen.push(n);
+        if (n === 3) throw new Error('county 3 exploded');
+        await new Promise((r) => setTimeout(r, 1));
+        return n;
+      })
+    ).rejects.toThrow('county 3 exploded');
+    // Stops starting new work after the failure — no silent full-run.
+    expect(seen.length).toBeLessThan(8);
+  });
+
+  it('Semaphore.run releases the permit on throw', async () => {
+    const sem = new Semaphore(1);
+    await expect(sem.run(async () => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+    // Permit must be back — a second run would hang forever otherwise.
+    await expect(sem.run(async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('Semaphore rejects a non-positive limit', () => {
+    expect(() => new Semaphore(0)).toThrow(/positive integer/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadWithRetry — backoff, jitter, Retry-After, fail-loud
+// ---------------------------------------------------------------------------
+
+describe('downloadWithRetry', () => {
+  it('returns the body on first success without sleeping', async () => {
+    const body = completeZipBuffer();
+    const fetchImpl = vi.fn(async () => okResponse(body));
+    const sleep = vi.fn(noSleep);
+    const buf = await downloadWithRetry('https://example.test/a.zip', { fetchImpl, sleep });
+    expect(Buffer.compare(buf, body)).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('backs off exponentially with jitter between failures', async () => {
+    const body = completeZipBuffer();
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error('terminated'))
+      .mockRejectedValueOnce(new Error('terminated'))
+      .mockResolvedValueOnce(okResponse(body));
+    const sleep = vi.fn(noSleep);
+    const random = () => 1; // deterministic top-of-jitter-band (100%)
+
+    await downloadWithRetry('https://example.test/b.zip', {
+      fetchImpl,
+      sleep,
+      random,
+      baseDelayMs: 1_000,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 1_000); // base * 2^0 * 1.0
+    expect(sleep).toHaveBeenNthCalledWith(2, 2_000); // base * 2^1 * 1.0
+  });
+
+  it('jitter keeps delays within [50%, 100%] of the exponential step', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error('terminated'))
+      .mockResolvedValueOnce(okResponse(completeZipBuffer()));
+    const sleep = vi.fn(noSleep);
+    const random = () => 0; // deterministic bottom-of-band (50%)
+    await downloadWithRetry('https://example.test/c.zip', {
+      fetchImpl,
+      sleep,
+      random,
+      baseDelayMs: 1_000,
+    });
+    expect(sleep).toHaveBeenCalledWith(500);
+  });
+
+  it('caps the exponential step at maxDelayMs', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error('terminated'))
+      .mockRejectedValueOnce(new Error('terminated'))
+      .mockRejectedValueOnce(new Error('terminated'))
+      .mockResolvedValueOnce(okResponse(completeZipBuffer()));
+    const sleep = vi.fn(noSleep);
+    await downloadWithRetry('https://example.test/d.zip', {
+      fetchImpl,
+      sleep,
+      random: () => 1,
+      baseDelayMs: 1_000,
+      maxDelayMs: 1_500,
+    });
+    expect(sleep).toHaveBeenNthCalledWith(1, 1_000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 1_500); // capped, not 2000
+    expect(sleep).toHaveBeenNthCalledWith(3, 1_500); // capped, not 4000
+  });
+
+  it('honors Retry-After (seconds) on 429 when longer than the backoff', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response('slow down', { status: 429, headers: { 'retry-after': '30' } })
+      )
+      .mockResolvedValueOnce(okResponse(completeZipBuffer()));
+    const sleep = vi.fn(noSleep);
+    await downloadWithRetry('https://example.test/e.zip', {
+      fetchImpl,
+      sleep,
+      random: () => 1,
+      baseDelayMs: 1_000,
+    });
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(30_000); // Retry-After wins over 1s backoff
+  });
+
+  it('fails loud after exhausting retries, naming the url', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error('terminated'));
+    const sleep = vi.fn(noSleep);
+    await expect(
+      downloadWithRetry('https://example.test/tl_2025_18013_addrfeat.zip', {
+        fetchImpl,
+        sleep,
+        maxRetries: 4,
+      })
+    ).rejects.toThrow(
+      'Download failed after 4 attempts: https://example.test/tl_2025_18013_addrfeat.zip: terminated'
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledTimes(3); // no sleep after the final attempt
+  });
+
+  it('treats non-2xx as a retryable failure', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('busy', { status: 503, statusText: 'Service Unavailable' }))
+      .mockResolvedValueOnce(okResponse(completeZipBuffer()));
+    const sleep = vi.fn(noSleep);
+    await downloadWithRetry('https://example.test/f.zip', { fetchImpl, sleep });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds', () => {
+    expect(parseRetryAfterMs('7')).toBe(7_000);
+  });
+  it('parses an HTTP-date relative to now', () => {
+    const now = Date.parse('2026-01-01T00:00:00Z');
+    expect(parseRetryAfterMs('Thu, 01 Jan 2026 00:00:45 GMT', now)).toBe(45_000);
+  });
+  it('clamps absurd values to 5 minutes', () => {
+    expect(parseRetryAfterMs('86400')).toBe(300_000);
+  });
+  it('returns null for absent or garbage headers', () => {
+    expect(parseRetryAfterMs(null)).toBeNull();
+    expect(parseRetryAfterMs('soon')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zip cache — verified-complete reuse (resume without re-downloading)
+// ---------------------------------------------------------------------------
+
+describe('downloadZipToCache', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'addrfeat-pool-test-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('cache hit: a verified-complete zip skips the download entirely', async () => {
+    const cached = join(dir, 'tl_2025_10001_addrfeat.zip');
+    writeFileSync(cached, completeZipBuffer());
+    const fetchImpl = vi.fn<typeof fetch>();
+    const result = await downloadZipToCache('https://example.test/g.zip', cached, { fetchImpl });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result.reused).toBe(true);
+    expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.bytes).toBe(completeZipBuffer().length);
+  });
+
+  it('cache miss: downloads, verifies, and persists the zip', async () => {
+    const body = completeZipBuffer(128);
+    const cached = join(dir, 'nested', 'tl_2025_44001_addrfeat.zip');
+    const fetchImpl = vi.fn(async () => okResponse(body));
+    const result = await downloadZipToCache('https://example.test/h.zip', cached, { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.reused).toBe(false);
+    expect(Buffer.compare(readFileSync(cached), body)).toBe(0);
+  });
+
+  it('a truncated cached zip (no EOCD) is re-downloaded, not trusted', async () => {
+    const cached = join(dir, 'tl_2025_18013_addrfeat.zip');
+    writeFileSync(cached, truncatedZipBuffer());
+    const body = completeZipBuffer(256);
+    const fetchImpl = vi.fn(async () => okResponse(body));
+    const result = await downloadZipToCache('https://example.test/i.zip', cached, { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.reused).toBe(false);
+    expect(Buffer.compare(readFileSync(cached), body)).toBe(0);
+  });
+
+  it('fails loud when the server returns a non-zip body with HTTP 200', async () => {
+    const cached = join(dir, 'tl_2025_18013_addrfeat.zip');
+    const fetchImpl = vi.fn(async () => okResponse(Buffer.from('<html>throttled</html>')));
+    await expect(
+      downloadZipToCache('https://example.test/j.zip', cached, { fetchImpl })
+    ).rejects.toThrow(/not a complete zip/);
+  });
+});
+
+describe('isCompleteZipBuffer', () => {
+  it('accepts magic + EOCD', () => {
+    expect(isCompleteZipBuffer(completeZipBuffer())).toBe(true);
+  });
+  it('rejects missing EOCD (truncated)', () => {
+    expect(isCompleteZipBuffer(truncatedZipBuffer())).toBe(false);
+  });
+  it('rejects non-zip bodies and tiny buffers', () => {
+    expect(isCompleteZipBuffer(Buffer.from('<html>err</html>'))).toBe(false);
+    expect(isCompleteZipBuffer(Buffer.from('PK'))).toBe(false);
+  });
+});

--- a/packages/shadow-atlas/src/distribution/addresses/download-pool.ts
+++ b/packages/shadow-atlas/src/distribution/addresses/download-pool.ts
@@ -1,0 +1,247 @@
+/**
+ * Bounded-parallel download pool for census.gov bulk fetches.
+ *
+ * Census throttles long sequential bulk fetchers ('terminated' mid-body after
+ * hours of one-at-a-time requests — observed on the national ADDRFEAT crawl).
+ * The cure is the opposite shape: a SMALL bounded pool (default 6 concurrent,
+ * Census-friendly) where each request carries exponential backoff + jitter,
+ * honors Retry-After on 429/503, and re-fetches through a per-attempt timeout
+ * so a hung socket can never stall the pool.
+ *
+ * Fail-loud discipline: exhausting retries THROWS with the url — a missing
+ * county must never be silently skipped (the index would carry a silent
+ * geographic hole).
+ *
+ * All effects (fetch, sleep, random) are injectable for unit tests.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Semaphore — the bounded-concurrency primitive the pipeline runs on
+// ---------------------------------------------------------------------------
+
+export class Semaphore {
+  private available: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(readonly limit: number) {
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new Error(`Semaphore limit must be a positive integer, got ${limit}`);
+    }
+    this.available = limit;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--;
+      return;
+    }
+    await new Promise<void>((resolve) => this.waiters.push(resolve));
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next(); // hand the permit straight to the next waiter
+    } else {
+      this.available++;
+    }
+  }
+
+  /** Run fn under a permit; always releases, even on throw. */
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+}
+
+/**
+ * Map fn over items with at most `concurrency` in flight. Rejects with the
+ * first error AFTER in-flight work settles (no unhandled rejections, no
+ * silently-skipped items). Result order matches input order.
+ */
+export async function runBoundedPool<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const sem = new Semaphore(concurrency);
+  const results = new Array<R>(items.length);
+  const errors: unknown[] = [];
+  await Promise.all(
+    items.map((item, i) =>
+      sem.run(async () => {
+        if (errors.length > 0) return; // stop starting new work after a failure
+        try {
+          results[i] = await fn(item, i);
+        } catch (err) {
+          errors.push(err);
+        }
+      })
+    )
+  );
+  if (errors.length > 0) throw errors[0];
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Retrying download — exponential backoff + jitter + Retry-After
+// ---------------------------------------------------------------------------
+
+export interface DownloadRetryOptions {
+  /** Total attempts before failing loud. Default 6. */
+  maxRetries?: number;
+  /** First backoff delay; doubles each attempt. Default 2000 ms. */
+  baseDelayMs?: number;
+  /** Backoff ceiling (Retry-After may exceed it, clamped to 5 min). Default 60000 ms. */
+  maxDelayMs?: number;
+  /** Per-attempt timeout — a hung socket must not stall the pool. Default 120000 ms. */
+  timeoutMs?: number;
+  /** Injectable effects (tests). */
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+}
+
+const RETRY_AFTER_CLAMP_MS = 5 * 60_000;
+
+/** Parse a Retry-After header (delta-seconds or HTTP-date) into ms, or null. */
+export function parseRetryAfterMs(header: string | null, nowMs: number = Date.now()): number | null {
+  if (header === null || header.trim().length === 0) return null;
+  const trimmed = header.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Math.min(parseInt(trimmed, 10) * 1000, RETRY_AFTER_CLAMP_MS);
+  }
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) return null;
+  return Math.min(Math.max(dateMs - nowMs, 0), RETRY_AFTER_CLAMP_MS);
+}
+
+class HttpStatusError extends Error {
+  constructor(
+    readonly status: number,
+    statusText: string,
+    readonly retryAfterMs: number | null
+  ) {
+    super(`HTTP ${status}: ${statusText}`);
+  }
+}
+
+/**
+ * Fetch url → Buffer with maxRetries attempts. Backoff between attempts is
+ * exponential with 50-100% jitter; a Retry-After on 429/503 overrides the
+ * computed backoff when longer. Exhaustion throws (fail-loud) with the url.
+ */
+export async function downloadWithRetry(
+  url: string,
+  options: DownloadRetryOptions = {}
+): Promise<Buffer> {
+  const maxRetries = options.maxRetries ?? 6;
+  const baseDelayMs = options.baseDelayMs ?? 2_000;
+  const maxDelayMs = options.maxDelayMs ?? 60_000;
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const random = options.random ?? Math.random;
+
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+      if (!response.ok) {
+        const retryAfterMs =
+          response.status === 429 || response.status === 503
+            ? parseRetryAfterMs(response.headers.get('retry-after'))
+            : null;
+        throw new HttpStatusError(response.status, response.statusText, retryAfterMs);
+      }
+      return Buffer.from(await response.arrayBuffer());
+    } catch (error) {
+      lastError = error as Error;
+      if (attempt < maxRetries) {
+        // Exponential backoff with 50-100% jitter (decorrelates a pool of
+        // failing fetchers so retries don't stampede census.gov in lockstep).
+        const exp = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+        const jittered = Math.round(exp * (0.5 + random() * 0.5));
+        const retryAfterMs =
+          lastError instanceof HttpStatusError ? lastError.retryAfterMs : null;
+        const delayMs = retryAfterMs !== null ? Math.max(retryAfterMs, jittered) : jittered;
+        console.warn(
+          `  download attempt ${attempt}/${maxRetries} failed (${lastError.message}); retrying in ${delayMs} ms: ${url}`
+        );
+        await sleep(delayMs);
+      }
+    }
+  }
+  throw new Error(`Download failed after ${maxRetries} attempts: ${url}: ${lastError?.message}`);
+}
+
+// ---------------------------------------------------------------------------
+// Zip cache — resume-after-restart without re-downloading verified files
+// ---------------------------------------------------------------------------
+
+/**
+ * A cached zip is verified-complete iff it starts with the zip local-file
+ * magic (PK\x03\x04) AND carries an end-of-central-directory record in its
+ * tail — a truncated download passes the magic check but never the EOCD one.
+ */
+export function isCompleteZipBuffer(buf: Buffer): boolean {
+  if (buf.length < 22) return false;
+  if (!(buf[0] === 0x50 && buf[1] === 0x4b && buf[2] === 0x03 && buf[3] === 0x04)) return false;
+  // EOCD signature PK\x05\x06 sits within the last 22 + 65535 bytes (comment).
+  const tail = buf.subarray(Math.max(0, buf.length - (22 + 65_535)));
+  return tail.lastIndexOf(Buffer.from([0x50, 0x4b, 0x05, 0x06])) !== -1;
+}
+
+export interface CachedDownloadResult {
+  path: string;
+  bytes: number;
+  sha256: string;
+  /** true when a verified-complete cached file was reused (no fetch issued). */
+  reused: boolean;
+}
+
+/**
+ * Download url into cachePath unless a verified-complete zip is already
+ * there (keyed by filename + non-trivial size + zip magic + EOCD). Always
+ * returns the computed sha256 — census.gov publishes no pins; we stamp what
+ * we compute.
+ */
+export async function downloadZipToCache(
+  url: string,
+  cachePath: string,
+  options: DownloadRetryOptions = {}
+): Promise<CachedDownloadResult> {
+  if (existsSync(cachePath) && statSync(cachePath).size > 4) {
+    const candidate = readFileSync(cachePath);
+    if (isCompleteZipBuffer(candidate)) {
+      return {
+        path: cachePath,
+        bytes: candidate.length,
+        sha256: createHash('sha256').update(candidate).digest('hex'),
+        reused: true,
+      };
+    }
+  }
+  const buf = await downloadWithRetry(url, options);
+  if (!isCompleteZipBuffer(buf)) {
+    // Fail-loud: census served bytes that are not a complete zip (throttling
+    // proxies have been observed truncating bodies with HTTP 200).
+    throw new Error(`Downloaded file is not a complete zip (${buf.length} bytes): ${url}`);
+  }
+  mkdirSync(dirname(cachePath), { recursive: true });
+  writeFileSync(cachePath, buf);
+  return {
+    path: cachePath,
+    bytes: buf.length,
+    sha256: createHash('sha256').update(buf).digest('hex'),
+    reused: false,
+  };
+}


### PR DESCRIPTION
First national run (28679320982) died ~5h in: sequential county loop hit a Census throttle kill at tl_2025_18013 after reaching only Indiana (~2.3 counties/min → ~23h national vs the 300-min ceiling). Now: bounded download pool (6, backoff+jitter+Retry-After), forked transform workers with FIPS-ordered ingest (output byte-identical — diff-proven vs the sequential build), verified zip cache + actions/cache save-on-failure for resume, ceiling 360. Real DE/RI smoke: 79.4 counties/min cold, 8/8 cache hits warm → national ~41min local, ≤325min even at 8× runner derate. 62/62 address-index tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved address-index processing with faster, bounded-parallel downloads and worker-based transforms.
  * Added support for resuming partially completed address data downloads, reducing wasted work after interruptions.
  * Introduced optional tuning for download and transform parallelism.

* **Bug Fixes**
  * Made address-index builds more resilient to long-running jobs by increasing the allowed runtime.
  * Improved handling of incomplete or truncated cached downloads so corrupted files are re-fetched automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->