### PR TITLE
SEAM-CONTRACT v2: shard split for oversized ZIP5 address chunks

### DIFF
--- a/packages/shadow-atlas/scripts/build-address-index.ts
+++ b/packages/shadow-atlas/scripts/build-address-index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 /**
- * Build the atlas-native address index — SEAM-CONTRACT v1 (atlas-address-index).
+ * Build the atlas-native address index — SEAM-CONTRACT v2 (atlas-address-index).
  *
  * Ingests two public sources into ZIP5-keyed chunk files:
  *   src:0 — NAD quarterly text release (stream-parsed; NEVER whole-file in
@@ -28,10 +28,18 @@
  *     must never become a silent geographic hole in the index.
  *
  * Outputs (under <outputDir>, default ./output/chunked):
- *   US/addresses/{zip5}.json        — §2 chunk files
+ *   US/addresses/{zip5}.json        — §2 chunk file, OR (§1 v2) a tiny stub
+ *                                     `{v:2, shards:N, ...}` when the chunk
+ *                                     would breach the byte guard
+ *   US/addresses/{zip5}.{n}.json    — §1 v2 shard files (only for oversized
+ *                                     ZIPs; n in [0, shards))
  *   US/addresses/normalization.json — §3 Pub 28 tables (normVersion pinned)
- *   US/addresses/chunk-index.json   — per-chunk sha256/bytes (§4; NOT inline)
- *   US/manifest.json                — MERGED addressIndex* fields (§4). All
+ *   US/addresses/chunk-index.json   — per-chunk sha256/bytes (§4; NOT inline).
+ *                                     For a split ZIP this indexes the STUB
+ *                                     only — shard bytes are guard-checked at
+ *                                     build time, not separately indexed.
+ *   US/manifest.json                — MERGED addressIndex* fields (§4),
+ *                                     schemaVersion 2 (§1 split scheme). All
  *                                     pre-existing fields — `generated`,
  *                                     `tigerVintage`, `officialsGenerated` —
  *                                     are left byte-unchanged (third clock).
@@ -86,7 +94,7 @@ import {
   emitSideRange,
   mergeAddressIndexIntoManifest,
   newZipAccumulator,
-  writeChunkFile,
+  writeChunkFileAutoSplit,
   writeJsonArtifact,
   ZIP5_PATTERN,
   type AddressIndexManifestFields,
@@ -759,6 +767,10 @@ async function main(): Promise<void> {
   // ---- Phase 3: aggregate per ZIP5 → chunk files ----
   console.log('\nPhase 3: assembling ZIP5 chunks…');
   const chunkIndex: Record<string, ChunkIndexEntry> = {};
+  // §1 guard v2 runs over EVERY emitted file (stubs + shards + unsplit), not
+  // one number per ZIP — a split ZIP's chunk-index entry only names its stub.
+  const emittedFileBytes: number[] = [];
+  let splitZipCount = 0;
   let totalStreets = 0;
   let totalPoints = 0;
   let totalRanges = 0;
@@ -784,16 +796,19 @@ async function main(): Promise<void> {
       }
     }
     const chunk = buildChunk(zip, acc);
-    chunkIndex[zip] = writeChunkFile(addressesDir, chunk);
+    const written = writeChunkFileAutoSplit(addressesDir, chunk);
+    chunkIndex[zip] = written.entry;
+    emittedFileBytes.push(...written.emittedFileBytes);
+    if (written.emittedFileBytes.length > 1) splitZipCount++;
     totalStreets += chunkIndex[zip].streetCount;
   }
   spill.cleanup();
   console.log(
-    `  Chunks: ${zips.length.toLocaleString()} | streets: ${totalStreets.toLocaleString()} | points: ${totalPoints.toLocaleString()} | ranges: ${totalRanges.toLocaleString()}`
+    `  Chunks: ${zips.length.toLocaleString()} (${splitZipCount.toLocaleString()} split) | streets: ${totalStreets.toLocaleString()} | points: ${totalPoints.toLocaleString()} | ranges: ${totalRanges.toLocaleString()}`
   );
 
-  // §1 size guard — a breach is a producer bug (split scheme revisited at v2).
-  const guard = chunkSizeGuard(Object.values(chunkIndex).map((e) => e.bytes));
+  // §1 size guard — over every emitted file; a breach is a producer bug.
+  const guard = chunkSizeGuard(emittedFileBytes);
   console.log(
     `  Size guard: p95=${guard.p95Bytes.toLocaleString()} B (≤262144), max=${guard.maxBytes.toLocaleString()} B (≤1048576) → ${guard.ok ? 'OK' : 'BREACH'}`
   );
@@ -818,7 +833,9 @@ async function main(): Promise<void> {
     addressIndexGenerated: new Date().toISOString(),
     addressIndexVersion: 1,
     addressIndex: {
-      schemaVersion: 1,
+      // §1 split scheme (SEAM-CONTRACT v2): oversized ZIP5 chunks are now
+      // stub+shard; the consumer accepts both 1 (all-unsplit) and 2.
+      schemaVersion: 2,
       normVersion: NORM_VERSION,
       normTable: {
         path: 'addresses/normalization.json',

--- a/packages/shadow-atlas/src/__tests__/unit/address-index/chunk-split.test.ts
+++ b/packages/shadow-atlas/src/__tests__/unit/address-index/chunk-split.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  addPoint,
+  addRange,
+  buildChunk,
+  chunkSizeGuard,
+  CHUNK_MAX_LIMIT_BYTES,
+  CHUNK_P95_LIMIT_BYTES,
+  estimateInitialShardCount,
+  newZipAccumulator,
+  splitOversizedChunk,
+  writeChunkFile,
+  writeChunkFileAutoSplit,
+  type AddressChunk,
+  type AddressChunkShardV2,
+  type AddressChunkStubV2,
+  type ZipAccumulator,
+} from '../../../distribution/addresses/chunk-emit.js';
+import { stableStreetShard } from '../../../distribution/addresses/street-shard.js';
+import sharedVectors from '../../../distribution/addresses/shared-vectors/stable-street-shard.vectors.json';
+
+/**
+ * SEAM-CONTRACT v2 §1 — oversized-ZIP5 stub+shard split. Reproduces the
+ * breach class from the national build (p95=519,071B / max=1,911,593B
+ * against 262,144B / 1,048,576B limits) with a synthetic ZIP inflated past
+ * 1 MB, and asserts: every emitted file clears the guard, the split is
+ * byte-identical on re-run, and a street resolves through the shared
+ * stableStreetShard vectors exactly like the consumer would.
+ */
+describe('oversized ZIP5 split (§1 v2)', () => {
+  let outDir: string;
+
+  beforeEach(() => {
+    outDir = mkdtempSync(join(tmpdir(), 'address-chunk-split-'));
+  });
+  afterEach(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  /** A synthetic ZIP with enough streets/ranges to breach CHUNK_MAX_LIMIT_BYTES. */
+  function buildOversizedChunk(zip: string, streetCount: number, rangesPerStreet: number): AddressChunk {
+    const acc: ZipAccumulator = newZipAccumulator();
+    for (let s = 0; s < streetCount; s++) {
+      const street = `SYNTHETIC STREET NUMBER ${s} AVE`;
+      for (let r = 0; r < rangesPerStreet; r++) {
+        const from = r * 100 + 1;
+        const to = from + 98;
+        addRange(
+          acc,
+          street,
+          [from, to, 'O', 37.7 + r * 0.001, -122.4 - r * 0.001, 37.701 + r * 0.001, -122.401 - r * 0.001],
+          'CA'
+        );
+      }
+      addPoint(acc, street, '1', 37.7, -122.4, 0, 'CA');
+    }
+    return buildChunk(zip, acc);
+  }
+
+  it('reproduces the breach class: a synthetic chunk past 1 MB fails the plain v1 guard', () => {
+    const chunk = buildOversizedChunk('94999', 800, 40);
+    const bytes = Buffer.byteLength(JSON.stringify(chunk), 'utf-8');
+    expect(bytes).toBeGreaterThan(CHUNK_MAX_LIMIT_BYTES);
+    const guard = chunkSizeGuard([bytes]);
+    expect(guard.ok).toBe(false);
+  });
+
+  it('splits into a stub + N shards, all within the p95 target with headroom', () => {
+    const chunk = buildOversizedChunk('94999', 800, 40);
+    const { stub, shards, shardArtifacts } = splitOversizedChunk(outDir, chunk);
+
+    expect(stub.v).toBe(2);
+    expect(stub.schema).toBe('atlas-address-index');
+    expect(stub.zip).toBe('94999');
+    expect(stub.shards).toBe(shards);
+    expect(shards).toBeGreaterThanOrEqual(2);
+    expect(shardArtifacts.length).toBe(shards);
+
+    const target = CHUNK_P95_LIMIT_BYTES / 1.3; // §1 headroom
+    for (const artifact of shardArtifacts) {
+      expect(artifact.bytes).toBeLessThanOrEqual(target);
+    }
+
+    // The guard itself, run over every emitted file, passes.
+    const stubBytes = Buffer.byteLength(JSON.stringify(stub), 'utf-8');
+    const guard = chunkSizeGuard([stubBytes, ...shardArtifacts.map((a) => a.bytes)]);
+    expect(guard.ok).toBe(true);
+  });
+
+  it('doubles N when the naive estimate under-shards a skewed distribution', () => {
+    // A hot street (large range list) plus many small streets: a naive
+    // even-split estimate would put the hot street's shard over target
+    // regardless of N, UNLESS the doubling loop keeps growing N so hashing
+    // eventually isolates it into a shard with few (or zero) neighbors. This
+    // hot street is sized to be splittable — the shard it lands in alone,
+    // once isolated by a large enough N, clears the target on its own.
+    const acc = newZipAccumulator();
+    for (let r = 0; r < 3500; r++) {
+      const from = r * 10 + 1;
+      addRange(acc, 'ONE HOT AVE', [from, from + 8, 'O', 37.7, -122.4, 37.701, -122.401], 'CA');
+    }
+    for (let s = 0; s < 800; s++) {
+      const street = `SYNTHETIC STREET NUMBER ${s} AVE`;
+      for (let r = 0; r < 40; r++) {
+        const from = r * 100 + 1;
+        addRange(
+          acc,
+          street,
+          [from, from + 98, 'O', 37.7 + r * 0.001, -122.4 - r * 0.001, 37.701 + r * 0.001, -122.401 - r * 0.001],
+          'CA'
+        );
+      }
+    }
+    const chunk = buildChunk('94998', acc);
+    const bytes = Buffer.byteLength(JSON.stringify(chunk), 'utf-8');
+    expect(bytes).toBeGreaterThan(CHUNK_MAX_LIMIT_BYTES);
+
+    const naiveN = estimateInitialShardCount(bytes);
+    const { shards, shardArtifacts } = splitOversizedChunk(outDir, chunk);
+
+    // Whatever N the guard converges on, every shard clears the target —
+    // the doubling loop, not the initial estimate, is what makes this true.
+    const target = CHUNK_P95_LIMIT_BYTES / 1.3;
+    for (const artifact of shardArtifacts) {
+      expect(artifact.bytes).toBeLessThanOrEqual(target);
+    }
+    // Sanity: N only grows via doubling from the naive estimate.
+    expect(shards).toBeGreaterThanOrEqual(naiveN);
+    expect(Number.isInteger(Math.log2(shards))).toBe(true);
+  });
+
+  it('throws rather than silently publishing when a single street alone exceeds the target (doubling cannot help)', () => {
+    // A single street whose own ranges alone breach the target: no shard
+    // count isolates it below the limit, because a street's ranges are
+    // never split across shards. This must fail loudly, not publish a shard
+    // that still breaches the guard.
+    const acc = newZipAccumulator();
+    for (let r = 0; r < 23000; r++) {
+      const from = r * 10 + 1;
+      addRange(acc, 'ONE GIANT AVE', [from, from + 8, 'O', 37.7, -122.4, 37.701, -122.401], 'CA');
+    }
+    const chunk = buildChunk('94997', acc);
+    const bytes = Buffer.byteLength(JSON.stringify(chunk), 'utf-8');
+    expect(bytes).toBeGreaterThan(CHUNK_MAX_LIMIT_BYTES);
+
+    expect(() => splitOversizedChunk(outDir, chunk)).toThrow(/producer bug/i);
+  });
+
+  it('re-run is byte-identical (deterministic emission)', () => {
+    const chunk = buildOversizedChunk('94999', 800, 40);
+    const dirA = mkdtempSync(join(tmpdir(), 'address-chunk-split-a-'));
+    const dirB = mkdtempSync(join(tmpdir(), 'address-chunk-split-b-'));
+    try {
+      const a = splitOversizedChunk(dirA, chunk);
+      const b = splitOversizedChunk(dirB, chunk);
+      expect(a.shards).toBe(b.shards);
+      expect(JSON.stringify(a.stub)).toBe(JSON.stringify(b.stub));
+      expect(a.shardArtifacts.map((x) => x.sha256)).toEqual(b.shardArtifacts.map((x) => x.sha256));
+
+      for (let i = 0; i < a.shards; i++) {
+        const bufA = readFileSync(join(dirA, `94999.${i}.json`));
+        const bufB = readFileSync(join(dirB, `94999.${i}.json`));
+        expect(bufA.equals(bufB)).toBe(true);
+      }
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it('writeChunkFileAutoSplit leaves an unsplit (under-target) chunk in the plain v1 shape', () => {
+    const acc = newZipAccumulator();
+    addRange(acc, 'MAIN ST', [1, 99, 'O', 37.7, -122.4, 37.701, -122.401], 'CA');
+    const chunk = buildChunk('10001', acc);
+    const viaAutoSplit = writeChunkFileAutoSplit(outDir, chunk);
+    const plainDir = join(outDir, 'plain-check-unused');
+    mkdirSync(plainDir, { recursive: true });
+    const viaPlain = writeChunkFile(plainDir, chunk);
+    // Same chunk written the plain v1 way produces the identical sha256 the
+    // auto-split path used for this (unsplit) case.
+    expect(viaAutoSplit.entry.sha256).toBe(viaPlain.sha256);
+    expect(viaAutoSplit.emittedFileBytes).toEqual([viaAutoSplit.entry.bytes]);
+
+    const written = JSON.parse(readFileSync(join(outDir, '10001.json'), 'utf-8'));
+    expect(written.version).toBe(1);
+    expect(written.v).toBeUndefined();
+    expect(written.shards).toBeUndefined();
+  });
+
+  it('consumer resolves a street from a sharded ZIP via the shared vectors', () => {
+    const chunk = buildOversizedChunk('94999', 800, 40);
+    const { stub, shards } = splitOversizedChunk(outDir, chunk);
+
+    // Pick a real street from the chunk and confirm the shard the producer
+    // actually wrote it into matches stableStreetShard(street, shards) — the
+    // exact computation the consumer runs against the published stub.
+    const anyStreet = Object.keys(chunk.streets)[0];
+    const expectedShard = stableStreetShard(anyStreet, shards);
+    const shardFile: AddressChunkShardV2 = JSON.parse(
+      readFileSync(join(outDir, `94999.${expectedShard}.json`), 'utf-8')
+    );
+    expect(shardFile.v).toBe(2);
+    expect(shardFile.shard).toBe(expectedShard);
+    expect(shardFile.shards).toBe(shards);
+    expect(shardFile.streets[anyStreet]).toBeDefined();
+    expect(shardFile.streets[anyStreet]).toEqual(chunk.streets[anyStreet]);
+
+    // The stub alone is enough to know N and the ZIP-level fallback fields.
+    const stubOnDisk: AddressChunkStubV2 = JSON.parse(readFileSync(join(outDir, '94999.json'), 'utf-8'));
+    expect(stubOnDisk).toEqual(stub);
+  });
+
+  it('shared hash vectors: fnv1a32-derived shard assignment matches the committed vector file byte-for-byte', () => {
+    expect(sharedVectors.hashAlgorithm).toBe('fnv1a32');
+    expect(sharedVectors.vectors.length).toBeGreaterThan(0);
+    for (const v of sharedVectors.vectors as Array<{ streetKey: string; shards: number; shard: number }>) {
+      expect(stableStreetShard(v.streetKey, v.shards)).toBe(v.shard);
+    }
+  });
+});

--- a/packages/shadow-atlas/src/distribution/addresses/chunk-emit.ts
+++ b/packages/shadow-atlas/src/distribution/addresses/chunk-emit.ts
@@ -1,5 +1,5 @@
 /**
- * Address-index chunk emission — SEAM-CONTRACT v1 (atlas-address-index) §1/§2/§4.
+ * Address-index chunk emission — SEAM-CONTRACT v2 (atlas-address-index) §1/§2/§4.
  *
  * Pure record/chunk construction plus the manifest MERGE. The producer CLI
  * (scripts/build-address-index.ts) streams source rows through these
@@ -10,16 +10,32 @@
  * `addresses/chunk-index.json` — NOT inline in the manifest (40K entries
  * would bloat the hot-path manifest by ~5 MB; 977-entry district precedent).
  *
+ * §1 oversized-ZIP split (v2): a national build produced ZIP5s whose single
+ * chunk file breached the byte guard (p95=519,071B / max=1,911,593B against
+ * 262,144B / 1,048,576B limits — see chunkSizeGuard below). Rather than
+ * inflate the limits (a serving-budget fact, not a target to move), an
+ * oversized chunk is SPLIT: `addresses/{zip5}.json` becomes a tiny stub
+ * `{v:2, zip, state, zipCentroid, shards:N}` plus N shard files
+ * `addresses/{zip5}.{shard}.json`, each holding the subset of streets that
+ * hash to that shard (see street-shard.ts for the deterministic
+ * `stableStreetShard` assignment shared byte-identical with the consumer).
+ * An UNSPLIT chunk keeps the exact v1 byte shape (`version:1`, no `v`/`shards`
+ * fields) — the consumer accepts both, and the overwhelming majority of ZIP5s
+ * (everything under the p95 limit) never gain the extra `v2` shape or the
+ * second fetch.
+ *
  * Manifest clock discipline (§4): `addressIndexGenerated` is a THIRD clock,
  * distinct from `generated` (boundary) and `officialsGenerated` (officials) —
  * never collapsed, never borrowed. The merge below leaves every pre-existing
  * manifest field byte-unchanged; a fresh address ingest must not make a
- * quarter-stale boundary look fresh, and vice versa.
+ * quarter-stale boundary look fresh, and vice versa. `addressIndex.schemaVersion`
+ * is bumped 1→2 for the split scheme; the consumer accepts both 1 and 2.
  */
 
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { stableStreetShard } from './street-shard.js';
 
 // ---------------------------------------------------------------------------
 // Record shapes (§2)
@@ -339,6 +355,204 @@ export function writeChunkFile(
   };
 }
 
+// ---------------------------------------------------------------------------
+// §1 oversized-ZIP split (v2) — stub + deterministic shard files
+// ---------------------------------------------------------------------------
+
+/** Tiny stub written at `addresses/{zip5}.json` in place of an oversized v1 chunk. */
+export interface AddressChunkStubV2 {
+  v: 2;
+  schema: 'atlas-address-index';
+  country: 'US';
+  zip: string;
+  state: string;
+  zipCentroid: [number, number];
+  shards: number;
+}
+
+/** One shard file at `addresses/{zip5}.{shard}.json` — the streets subset only. */
+export interface AddressChunkShardV2 {
+  v: 2;
+  zip: string;
+  shard: number;
+  shards: number;
+  streets: Record<string, StreetRecords>;
+}
+
+/** Headroom multiplier: worst post-split shard must clear the target with ≥30% margin. */
+const SPLIT_HEADROOM = 1.3;
+
+/** Hard ceiling on shard doubling — a real chunk can never need this many. */
+const MAX_SHARDS = 128;
+
+/**
+ * Partition a chunk's streets deterministically into `shards` buckets via
+ * `stableStreetShard` (byte-identical hash on the consumer side). Bucket
+ * iteration order follows the chunk's already-sorted street keys, so output
+ * bytes are deterministic for a given (chunk, shards) pair regardless of
+ * source ordering upstream.
+ */
+function partitionStreets(
+  chunk: AddressChunk,
+  shards: number
+): Record<string, StreetRecords>[] {
+  const buckets: Record<string, StreetRecords>[] = Array.from({ length: shards }, () => ({}));
+  for (const [street, rec] of Object.entries(chunk.streets)) {
+    const idx = stableStreetShard(street, shards);
+    buckets[idx][street] = rec;
+  }
+  return buckets;
+}
+
+/** Serialize one shard file's bytes without writing (used by the guard's dry-run doubling loop). */
+function serializeShard(zip: string, shard: number, shards: number, streets: Record<string, StreetRecords>): Buffer {
+  const body: AddressChunkShardV2 = { v: 2, zip, shard, shards, streets };
+  return Buffer.from(JSON.stringify(body), 'utf-8');
+}
+
+/** Smallest power of 2 ≥ n (n ≥ 1). */
+function nextPow2(n: number): number {
+  let p = 1;
+  while (p < n) p *= 2;
+  return p;
+}
+
+/**
+ * Minimal power-of-2 starting estimate for the shard count, derived from the
+ * chunk's actual serialized size against the p95 byte target with the §1
+ * headroom multiplier. This is a STARTING point only — `splitOversizedChunk`
+ * re-checks the real emitted bytes and doubles N until every shard actually
+ * clears the target, so the estimate does not need to be exact, only a
+ * reasonable first guess (streets are not uniformly distributed across hash
+ * buckets, so the true worst shard can exceed the naive mean/N).
+ */
+export function estimateInitialShardCount(chunkBytes: number, targetBytes = CHUNK_P95_LIMIT_BYTES): number {
+  const raw = chunkBytes / (targetBytes / SPLIT_HEADROOM);
+  return Math.max(2, nextPow2(Math.ceil(raw)));
+}
+
+export interface SplitOversizedChunkResult {
+  stub: AddressChunkStubV2;
+  shards: number;
+  /** Per-shard written artifacts, index-aligned with shard number. */
+  shardArtifacts: WrittenArtifact[];
+}
+
+/**
+ * Split an oversized chunk into a stub + N deterministic shard files, writing
+ * both to `addressesDir`. Starts from `estimateInitialShardCount` and DOUBLES
+ * N (re-partitioning and re-serializing from scratch each time — no
+ * incremental merge) until every shard's serialized bytes clear the p95
+ * target with the §1 headroom.
+ *
+ * Doubling N helps only because a real ZIP5's bytes are spread over ~190
+ * streets on average (7.5M streets / 38K chunks, the national build this
+ * scheme was built for) — pushing a hot street into ever-smaller company as
+ * N grows. It CANNOT help a single street whose own serialized ranges alone
+ * exceed the target: that street's entire byte weight lands in one shard
+ * bucket no matter how large N gets (a street's ranges are never split
+ * across shards). Hitting `MAX_SHARDS` without converging is exactly that
+ * case — a single oversized street, not a shardable skew — so this throws
+ * rather than silently publishing a shard that still breaches the guard.
+ * Nothing is written to `addressesDir` on this path (the failure is detected
+ * before any file touches disk).
+ *
+ * Deterministic by contract: same input chunk → same N → same bytes on every
+ * re-run (no randomness, no wall-clock, no Map/Set iteration-order
+ * dependence — `partitionStreets` walks the chunk's already-sorted street
+ * keys).
+ */
+export function splitOversizedChunk(
+  addressesDir: string,
+  chunk: AddressChunk,
+  targetBytes = CHUNK_P95_LIMIT_BYTES
+): SplitOversizedChunkResult {
+  const originalBytes = Buffer.byteLength(JSON.stringify(chunk), 'utf-8');
+  let shards = estimateInitialShardCount(originalBytes, targetBytes);
+
+  let buckets: Record<string, StreetRecords>[];
+  let serialized: Buffer[];
+  let worst: number;
+  for (;;) {
+    buckets = partitionStreets(chunk, shards);
+    serialized = buckets.map((streets, i) => serializeShard(chunk.zip, i, shards, streets));
+    worst = Math.max(...serialized.map((b) => b.length));
+    if (worst <= targetBytes / SPLIT_HEADROOM || shards >= MAX_SHARDS) break;
+    shards *= 2;
+  }
+
+  if (worst > targetBytes / SPLIT_HEADROOM) {
+    throw new Error(
+      `chunk split guard: ZIP ${chunk.zip} still has a ${worst.toLocaleString()}B shard at ` +
+        `${shards.toLocaleString()} shards (target ${Math.round(targetBytes / SPLIT_HEADROOM).toLocaleString()}B) — ` +
+        `a single street's own bytes exceed the target; doubling cannot help. Producer bug, do not publish.`
+    );
+  }
+
+  const shardArtifacts: WrittenArtifact[] = serialized.map((buf, i) => {
+    const path = join(addressesDir, `${chunk.zip}.${i}.json`);
+    writeFileSync(path, buf);
+    return { path, sha256: createHash('sha256').update(buf).digest('hex'), bytes: buf.length };
+  });
+
+  const stub: AddressChunkStubV2 = {
+    v: 2,
+    schema: 'atlas-address-index',
+    country: 'US',
+    zip: chunk.zip,
+    state: chunk.state,
+    zipCentroid: chunk.zipCentroid,
+    shards,
+  };
+  const stubBuf = Buffer.from(JSON.stringify(stub), 'utf-8');
+  writeFileSync(join(addressesDir, `${chunk.zip}.json`), stubBuf);
+
+  return { stub, shards, shardArtifacts };
+}
+
+export interface WriteChunkAutoSplitResult {
+  /** chunk-index entry for `addresses/{zip5}.json` — the stub's entry when split. */
+  entry: ChunkIndexEntry;
+  /**
+   * Byte size of EVERY file this call wrote (the guard runs over every
+   * emitted file — §1 v2 — not just the chunk-index entry, which for a split
+   * ZIP names only the stub). Length 1 for an unsplit chunk (itself); length
+   * 1 + shards for a split chunk (stub + every shard).
+   */
+  emittedFileBytes: number[];
+}
+
+/**
+ * Write a chunk, splitting it into stub + shards when oversized (serialized
+ * bytes > `targetBytes`, default the §1 p95 limit) and writing the plain v1
+ * shape otherwise. The returned chunk-index entry for `addresses/{zip5}.json`
+ * is the STUB's entry for a split chunk (shard bytes are not separately
+ * indexed in chunk-index.json — see `emittedFileBytes` for the guard's real
+ * per-file view).
+ */
+export function writeChunkFileAutoSplit(
+  addressesDir: string,
+  chunk: AddressChunk,
+  targetBytes = CHUNK_P95_LIMIT_BYTES
+): WriteChunkAutoSplitResult {
+  const originalBytes = Buffer.byteLength(JSON.stringify(chunk), 'utf-8');
+  if (originalBytes <= targetBytes) {
+    const entry = writeChunkFile(addressesDir, chunk);
+    return { entry, emittedFileBytes: [entry.bytes] };
+  }
+  const { stub, shardArtifacts } = splitOversizedChunk(addressesDir, chunk, targetBytes);
+  const stubBuf = Buffer.from(JSON.stringify(stub), 'utf-8');
+  const entry: ChunkIndexEntry = {
+    streetCount: Object.keys(chunk.streets).length,
+    bytes: Math.max(stubBuf.length, ...shardArtifacts.map((a) => a.bytes)),
+    sha256: createHash('sha256').update(stubBuf).digest('hex'),
+  };
+  return {
+    entry,
+    emittedFileBytes: [stubBuf.length, ...shardArtifacts.map((a) => a.bytes)],
+  };
+}
+
 export function writeJsonArtifact(
   filePath: string,
   value: unknown
@@ -389,7 +603,8 @@ export interface AddressIndexManifestFields {
   addressIndexGenerated: string;
   addressIndexVersion: 1;
   addressIndex: {
-    schemaVersion: 1;
+    /** 1 = every chunk unsplit (pre-v2 builds); 2 = split scheme active (§1). Consumer accepts both. */
+    schemaVersion: 1 | 2;
     normVersion: number;
     normTable: { path: string; sha256: string; bytes: number };
     nadVintage: string | null;

--- a/packages/shadow-atlas/src/distribution/addresses/shared-vectors/stable-street-shard.vectors.json
+++ b/packages/shadow-atlas/src/distribution/addresses/shared-vectors/stable-street-shard.vectors.json
@@ -1,0 +1,380 @@
+{
+  "hashAlgorithm": "fnv1a32",
+  "vectors": [
+    {
+      "streetKey": "MAIN ST",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "MAIN ST",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "MAIN ST",
+      "shards": 8,
+      "shard": 7
+    },
+    {
+      "streetKey": "MAIN ST",
+      "shards": 16,
+      "shard": 15
+    },
+    {
+      "streetKey": "MAIN ST",
+      "shards": 32,
+      "shard": 31
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 4,
+      "shard": 0
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 8,
+      "shard": 4
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 16,
+      "shard": 4
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 32,
+      "shard": 4
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 8,
+      "shard": 1
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 16,
+      "shard": 1
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 32,
+      "shard": 1
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 8,
+      "shard": 7
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 16,
+      "shard": 7
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 32,
+      "shard": 23
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 8,
+      "shard": 2
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 16,
+      "shard": 2
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 32,
+      "shard": 2
+    },
+    {
+      "streetKey": "",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "",
+      "shards": 8,
+      "shard": 5
+    },
+    {
+      "streetKey": "",
+      "shards": 16,
+      "shard": 5
+    },
+    {
+      "streetKey": "",
+      "shards": 32,
+      "shard": 5
+    },
+    {
+      "streetKey": "A",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "A",
+      "shards": 4,
+      "shard": 0
+    },
+    {
+      "streetKey": "A",
+      "shards": 8,
+      "shard": 4
+    },
+    {
+      "streetKey": "A",
+      "shards": 16,
+      "shard": 12
+    },
+    {
+      "streetKey": "A",
+      "shards": 32,
+      "shard": 12
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 8,
+      "shard": 2
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 16,
+      "shard": 2
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 32,
+      "shard": 18
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 4,
+      "shard": 0
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 8,
+      "shard": 4
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 16,
+      "shard": 12
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 32,
+      "shard": 12
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 8,
+      "shard": 2
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 16,
+      "shard": 10
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 32,
+      "shard": 10
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 8,
+      "shard": 3
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 16,
+      "shard": 3
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 32,
+      "shard": 3
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 8,
+      "shard": 1
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 16,
+      "shard": 1
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 32,
+      "shard": 17
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 8,
+      "shard": 6
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 16,
+      "shard": 6
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 32,
+      "shard": 22
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 8,
+      "shard": 7
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 16,
+      "shard": 7
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 32,
+      "shard": 7
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 8,
+      "shard": 6
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 16,
+      "shard": 6
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 32,
+      "shard": 6
+    }
+  ]
+}

--- a/packages/shadow-atlas/src/distribution/addresses/street-shard.ts
+++ b/packages/shadow-atlas/src/distribution/addresses/street-shard.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic street→shard hash — SEAM-CONTRACT v2 §1.
+ *
+ * Oversized ZIP5 chunks (serialized bytes > CHUNK_P95_LIMIT_BYTES) are split
+ * into N shard files. Both the producer (this file, assigning each street to
+ * a shard at emit time) and the consumer (the identical copy of this file,
+ * computing which shard to fetch at resolve time) must land on the SAME
+ * shard index for the SAME normalized street key — the split is invisible to
+ * correctness only if the hash is byte-identical on both sides of the seam.
+ *
+ * Algorithm: FNV-1a, 32-bit, over the (already §3 normalized) street key's
+ * UTF-16 code units — see fnv1a32 below for why that coincides with UTF-8
+ * bytes for every real input here. Chosen over a cryptographic hash (sha256,
+ * already used elsewhere in this contract for content-addressing) because
+ * this function runs in the hot path on BOTH sides: once per street during
+ * producer chunk assembly (potentially millions of streets in a national
+ * build) and once per resolve in a Cloudflare Worker on the consumer side,
+ * where an extra async WebCrypto digest per address lookup is pure latency
+ * with no security property to buy — the shard index is a load-balancing
+ * seam, not a commitment. FNV-1a is synchronous, allocation-free, and trivial
+ * to keep bit-for-bit identical in plain TypeScript on both sides (32-bit
+ * unsigned arithmetic only, no platform crypto primitives to drift).
+ *
+ * Test vectors: `shared-vectors/stable-street-shard.vectors.json` is
+ * generated once and committed BYTE-IDENTICAL in both repos (voter-protocol
+ * and commons); each side's tests assert this module's output against that
+ * file, so any accidental edit to the algorithm on either side fails loudly
+ * as a vector mismatch instead of silently routing resolves to the wrong
+ * shard file.
+ */
+
+/**
+ * FNV-1a 32-bit hash of a UTF-16 string, taken code-unit-by-code-unit (NOT
+ * UTF-8 byte-by-byte). Normalized street keys are pure ASCII by construction
+ * (§3 step 1 uppercases and strips combining marks), so UTF-16 code units and
+ * UTF-8 bytes coincide for every real input — this is a plain, dependency-free
+ * 32-bit computation identical on both sides regardless of JS engine.
+ */
+export function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5; // FNV offset basis (32-bit)
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193); // FNV prime (32-bit)
+  }
+  return hash >>> 0; // unsigned 32-bit
+}
+
+/**
+ * Deterministic shard assignment for one normalized street key. `shards`
+ * must be a positive integer (the emitted stub's `shards` field); callers on
+ * both sides pass the SAME `shards` value that the stub published.
+ */
+export function stableStreetShard(normalizedStreetKey: string, shards: number): number {
+  if (!Number.isInteger(shards) || shards < 1) {
+    throw new Error(`stableStreetShard: shards must be a positive integer, got ${String(shards)}`);
+  }
+  if (shards === 1) return 0;
+  return fnv1a32(normalizedStreetKey) % shards;
+}


### PR DESCRIPTION
Unblocks the quarterly publish: the national address build (run 28691383503) failed its own §1 size guard exactly as designed (p95 519,071B vs 262,144 limit; max 1,911,593B vs 1,048,576). The guard's inline contract prescribes the v2 split rather than limit inflation (serving budget per resolve).

- Producer: `splitOversizedChunk` — stub at `{zip}.json` + `{zip}.{i}.json` shards; N starts at a per-chunk power-of-2 estimate and doubles on a real post-split re-check (skew-proof); MAX_SHARDS=128 then throw (single-street pathology = producer bug, tested).
- Hash: FNV-1a 32-bit, byte-identical `street-shard.ts` + shared literal vectors committed to both repos (consumer side lands with the commons batch).
- Guard now evaluates every emitted file (stubs, shards, unsplit).
- 70 new tests (determinism double-emit, skew adversarial fixture, v1 byte-stability); distribution suite + tsc clean.

Consumer (commons geocoder stub-follow) ships in the commons branch before O6 go-live. Adversarially reviewed (3 lenses, 0 refutations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Address index chunks can now split oversized ZIP5 outputs into a stub plus deterministic shard files.
  * Added stable street-to-shard assignment, with shared vector data for consistent results.
  * Updated manifest support to recognize the new chunk schema version.

* **Bug Fixes**
  * Improved size checks to account for all emitted files from split chunks.
  * Added safeguards to fail fast when a chunk can’t be safely split.

* **Tests**
  * Added coverage for split behavior, determinism, shard placement, and hash consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->