### PR TITLE
Accept irreducible single-street shards within the hard per-file max

### DIFF
--- a/packages/shadow-atlas/scripts/build-address-index.ts
+++ b/packages/shadow-atlas/scripts/build-address-index.ts
@@ -800,6 +800,13 @@ async function main(): Promise<void> {
     chunkIndex[zip] = written.entry;
     emittedFileBytes.push(...written.emittedFileBytes);
     if (written.emittedFileBytes.length > 1) splitZipCount++;
+    if (written.floorAccepted) {
+      console.log(
+        `  ZIP ${zip}: irreducible single-street shard ${written.floorAccepted.worstShardBytes.toLocaleString()}B ` +
+          `at ${written.floorAccepted.shards} shards — over the headroom target, within the hard per-file max; ` +
+          `accepted (the §1 guard below stays the arbiter)`
+      );
+    }
     totalStreets += chunkIndex[zip].streetCount;
   }
   spill.cleanup();

--- a/packages/shadow-atlas/src/__tests__/unit/address-index/chunk-split.test.ts
+++ b/packages/shadow-atlas/src/__tests__/unit/address-index/chunk-split.test.ts
@@ -132,11 +132,11 @@ describe('oversized ZIP5 split (§1 v2)', () => {
     expect(Number.isInteger(Math.log2(shards))).toBe(true);
   });
 
-  it('throws rather than silently publishing when a single street alone exceeds the target (doubling cannot help)', () => {
-    // A single street whose own ranges alone breach the target: no shard
-    // count isolates it below the limit, because a street's ranges are
-    // never split across shards. This must fail loudly, not publish a shard
-    // that still breaches the guard.
+  it('throws rather than silently publishing when a single street alone exceeds the hard per-file max (sharding cannot help)', () => {
+    // A single street whose own ranges alone breach CHUNK_MAX_LIMIT_BYTES:
+    // no shard count isolates it below the contract's per-file line, because
+    // a street's ranges are never split across shards. This must fail
+    // loudly, not publish a file that breaches the guard's hard max.
     const acc = newZipAccumulator();
     for (let r = 0; r < 23000; r++) {
       const from = r * 10 + 1;
@@ -147,6 +147,64 @@ describe('oversized ZIP5 split (§1 v2)', () => {
     expect(bytes).toBeGreaterThan(CHUNK_MAX_LIMIT_BYTES);
 
     expect(() => splitOversizedChunk(outDir, chunk)).toThrow(/producer bug/i);
+  });
+
+  it('accepts an irreducible single-street shard between the headroom target and the hard max (the ZIP-23451 case)', () => {
+    // The national build surfaced exactly this: one street whose serialized
+    // ranges alone sit above target/headroom (~201KB) but well under the
+    // 1MB hard max. Doubling can never shrink it; refusing to publish would
+    // block a corpus that the real §1 guard (p95 + max over all files)
+    // accepts. The splitter must accept, flag via floorAccepted, and stop
+    // doubling early (irreducibility detection) instead of grinding to
+    // MAX_SHARDS.
+    const acc = newZipAccumulator();
+    // One hot street ~ mid-200KB serialized, plus enough small streets to
+    // push the whole chunk over the split threshold.
+    for (let r = 0; r < 5200; r++) {
+      const from = r * 10 + 1;
+      addRange(acc, 'ATLANTIC AVE', [from, from + 8, 'O', 36.85, -75.97, 36.851, -75.971], 'VA');
+    }
+    for (let s = 0; s < 120; s++) {
+      for (let r = 0; r < 12; r++) {
+        const from = r * 10 + 1;
+        addRange(acc, `SIDE ST ${s}`, [from, from + 8, 'E', 36.86, -75.98, 36.861, -75.981], 'VA');
+      }
+    }
+    const chunk = buildChunk('23451', acc);
+
+    const hotBytes = Buffer.byteLength(
+      JSON.stringify({ ['ATLANTIC AVE']: chunk.streets['ATLANTIC AVE'] }),
+      'utf-8'
+    );
+    const target = CHUNK_P95_LIMIT_BYTES / 1.3;
+    expect(hotBytes).toBeGreaterThan(target);
+    expect(hotBytes).toBeLessThanOrEqual(CHUNK_MAX_LIMIT_BYTES);
+
+    const result = splitOversizedChunk(outDir, chunk);
+    expect(result.floorAccepted).toBeDefined();
+    expect(result.floorAccepted!.worstShardBytes).toBeGreaterThan(target);
+    expect(result.floorAccepted!.worstShardBytes).toBeLessThanOrEqual(CHUNK_MAX_LIMIT_BYTES);
+    // Irreducibility detection stops the doubling early — never rides to
+    // MAX_SHARDS on a shard that cannot shrink.
+    expect(result.shards).toBeLessThan(128);
+    // Every emitted file exists and respects the hard max; every NON-worst
+    // shard cleared the headroom target (the skew is confined to the
+    // irreducible street's bucket).
+    const sizes = result.shardArtifacts.map((a) => a.bytes).sort((a, b) => b - a);
+    expect(sizes[0]).toBe(result.floorAccepted!.worstShardBytes);
+    for (const b of sizes) expect(b).toBeLessThanOrEqual(CHUNK_MAX_LIMIT_BYTES);
+    // Determinism holds on the floor-accept path too.
+    const dirB = mkdtempSync(join(tmpdir(), 'address-chunk-floor-b-'));
+    try {
+      const again = splitOversizedChunk(dirB, chunk);
+      expect(again.shards).toBe(result.shards);
+      expect(again.shardArtifacts.map((x) => x.sha256)).toEqual(
+        result.shardArtifacts.map((x) => x.sha256)
+      );
+      expect(again.floorAccepted).toEqual(result.floorAccepted);
+    } finally {
+      rmSync(dirB, { recursive: true, force: true });
+    }
   });
 
   it('re-run is byte-identical (deterministic emission)', () => {

--- a/packages/shadow-atlas/src/distribution/addresses/chunk-emit.ts
+++ b/packages/shadow-atlas/src/distribution/addresses/chunk-emit.ts
@@ -436,6 +436,16 @@ export interface SplitOversizedChunkResult {
   shards: number;
   /** Per-shard written artifacts, index-aligned with shard number. */
   shardArtifacts: WrittenArtifact[];
+  /**
+   * Set when the split converged on an irreducible shard above the headroom
+   * target: a single street whose own serialized ranges exceed
+   * `targetBytes / SPLIT_HEADROOM` (a street's ranges are never split across
+   * shards, so no shard count isolates it further). Accepted — not thrown —
+   * because the §1 contract's HARD limits are the corpus-wide p95 and the
+   * per-file max, both still enforced by `chunkSizeGuard` over every emitted
+   * file; the headroom target is the splitter's aim, not the contract line.
+   */
+  floorAccepted?: { worstShardBytes: number; shards: number };
 }
 
 /**
@@ -451,11 +461,18 @@ export interface SplitOversizedChunkResult {
  * N grows. It CANNOT help a single street whose own serialized ranges alone
  * exceed the target: that street's entire byte weight lands in one shard
  * bucket no matter how large N gets (a street's ranges are never split
- * across shards). Hitting `MAX_SHARDS` without converging is exactly that
- * case — a single oversized street, not a shardable skew — so this throws
- * rather than silently publishing a shard that still breaches the guard.
- * Nothing is written to `addressesDir` on this path (the failure is detected
- * before any file touches disk).
+ * across shards). Such an irreducible shard is ACCEPTED (with
+ * `floorAccepted` set so the caller can log it) as long as it clears the
+ * hard per-file `CHUNK_MAX_LIMIT_BYTES` — the headroom target is the
+ * splitter's aim, while the contract's real lines are the corpus-wide p95
+ * and the per-file max, both still enforced by `chunkSizeGuard` over every
+ * emitted file. (Real case: a national build surfaced a ~245KB single-street
+ * shard — within both hard limits; refusing to publish it was over-strict.)
+ * This throws ONLY when the irreducible shard exceeds the hard max itself —
+ * that would breach the contract no matter how the split is arranged, and
+ * would need range-level splitting (a v3 scheme change). Nothing is written
+ * to `addressesDir` on the throw path (the failure is detected before any
+ * file touches disk).
  *
  * Deterministic by contract: same input chunk → same N → same bytes on every
  * re-run (no randomness, no wall-clock, no Map/Set iteration-order
@@ -473,21 +490,28 @@ export function splitOversizedChunk(
   let buckets: Record<string, StreetRecords>[];
   let serialized: Buffer[];
   let worst: number;
+  let worstIsIrreducible: boolean;
   for (;;) {
     buckets = partitionStreets(chunk, shards);
     serialized = buckets.map((streets, i) => serializeShard(chunk.zip, i, shards, streets));
     worst = Math.max(...serialized.map((b) => b.length));
-    if (worst <= targetBytes / SPLIT_HEADROOM || shards >= MAX_SHARDS) break;
+    const worstIdx = serialized.findIndex((b) => b.length === worst);
+    // A worst shard holding exactly one street cannot shrink with more
+    // shards — a street's ranges are never split across shards.
+    worstIsIrreducible = Object.keys(buckets[worstIdx]).length <= 1;
+    if (worst <= targetBytes / SPLIT_HEADROOM || worstIsIrreducible || shards >= MAX_SHARDS) break;
     shards *= 2;
   }
 
-  if (worst > targetBytes / SPLIT_HEADROOM) {
+  if (worst > CHUNK_MAX_LIMIT_BYTES) {
     throw new Error(
-      `chunk split guard: ZIP ${chunk.zip} still has a ${worst.toLocaleString()}B shard at ` +
-        `${shards.toLocaleString()} shards (target ${Math.round(targetBytes / SPLIT_HEADROOM).toLocaleString()}B) — ` +
-        `a single street's own bytes exceed the target; doubling cannot help. Producer bug, do not publish.`
+      `chunk split guard: ZIP ${chunk.zip} has an irreducible ${worst.toLocaleString()}B shard ` +
+        `(hard max ${CHUNK_MAX_LIMIT_BYTES.toLocaleString()}B) — a single street's own bytes exceed the ` +
+        `per-file contract limit; sharding cannot help. Producer bug (needs range-level splitting), do not publish.`
     );
   }
+  const floorAccepted =
+    worst > targetBytes / SPLIT_HEADROOM ? { worstShardBytes: worst, shards } : undefined;
 
   const shardArtifacts: WrittenArtifact[] = serialized.map((buf, i) => {
     const path = join(addressesDir, `${chunk.zip}.${i}.json`);
@@ -507,7 +531,7 @@ export function splitOversizedChunk(
   const stubBuf = Buffer.from(JSON.stringify(stub), 'utf-8');
   writeFileSync(join(addressesDir, `${chunk.zip}.json`), stubBuf);
 
-  return { stub, shards, shardArtifacts };
+  return { stub, shards, shardArtifacts, ...(floorAccepted ? { floorAccepted } : {}) };
 }
 
 export interface WriteChunkAutoSplitResult {
@@ -520,6 +544,8 @@ export interface WriteChunkAutoSplitResult {
    * 1 + shards for a split chunk (stub + every shard).
    */
   emittedFileBytes: number[];
+  /** Present when the split accepted an irreducible over-target shard — see `SplitOversizedChunkResult.floorAccepted`. */
+  floorAccepted?: { worstShardBytes: number; shards: number };
 }
 
 /**
@@ -540,7 +566,7 @@ export function writeChunkFileAutoSplit(
     const entry = writeChunkFile(addressesDir, chunk);
     return { entry, emittedFileBytes: [entry.bytes] };
   }
-  const { stub, shardArtifacts } = splitOversizedChunk(addressesDir, chunk, targetBytes);
+  const { stub, shardArtifacts, floorAccepted } = splitOversizedChunk(addressesDir, chunk, targetBytes);
   const stubBuf = Buffer.from(JSON.stringify(stub), 'utf-8');
   const entry: ChunkIndexEntry = {
     streetCount: Object.keys(chunk.streets).length,
@@ -550,6 +576,7 @@ export function writeChunkFileAutoSplit(
   return {
     entry,
     emittedFileBytes: [stubBuf.length, ...shardArtifacts.map((a) => a.bytes)],
+    ...(floorAccepted ? { floorAccepted } : {}),
   };
 }
 


### PR DESCRIPTION
Unblocks the quarterly: attempt 3 (run 28702970067) failed at the splitter's own throw on ZIP 23451 — an irreducible ~245KB single-street shard that is comfortably inside both hard §1 limits. The headroom target is the splitter's aim, not the contract line; the corpus-wide guard over every emitted file stays the arbiter. Throw now reserved for irreducible shards over the 1MB hard max. New test reproduces the exact ZIP-23451 shape (accept + flag + early doubling stop + determinism); the >1MB single-street throw test unchanged. 90/90 address-index+distribution tests, tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oversized ZIP splitting so single-street chunks are accepted when they’re still within the hard file-size limit, even if they can’t be reduced to the preferred target size.
  * Prevented failures in edge cases where splitting can’t be tightened further, while still stopping if a chunk would exceed the maximum allowed size.
  * Added clearer logging and test coverage for this rare split scenario, including consistent results on repeat runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->