### PR TITLE
NAD download validation + probe content-shape checks

### DIFF
--- a/.github/workflows/shadow-atlas-quarterly.yml
+++ b/.github/workflows/shadow-atlas-quarterly.yml
@@ -797,19 +797,105 @@ jobs:
           mkdir -p data/addrfeat-cache
 
           if [ -n "$NAD_URL" ]; then
-            # Stream the NAD text release: the ~7.6 GB zip (and its ~30 GB
-            # uncompressed text) never touches the runner disk. The sha256 of
-            # the transferred zip bytes is computed on the same stream and
-            # stamped below — DOT publishes no pins, so we record what we
-            # compute (same posture as the census ADDRFEAT downloads, whose
-            # computed sha256s land in address-index-sources.json).
-            curl -sSL --retry 3 "$NAD_URL" \
-              | tee >(sha256sum | awk '{print $1}' > nad-download.sha256) \
-              | funzip \
+            # The NAD release is downloaded to disk first (not streamed)
+            # so its content can be validated as a complete zip before the
+            # multi-hour build consumes it. The upstream endpoint has been
+            # observed serving an HTTP-200 JSON error body in place of the
+            # archive during an outage — a streaming pipe (or a HEAD probe)
+            # cannot catch that until the downstream parser dies partway
+            # through the build, by which point real work is already lost.
+            #
+            # Disk math: the ~7.6 GB zip plus the ~2.8 GB ADDRFEAT cache
+            # fit comfortably within ubuntu-latest's free disk. The ~30 GB
+            # uncompressed NAD text still never touches disk — funzip
+            # streams it straight into the build below, exactly as before.
+            NAD_ZIP="data/nad-release.zip"
+            rm -f "$NAD_ZIP"
+
+            # Exit codes from validate_nad_zip: 0 = valid complete zip.
+            # 2 = body doesn't start with the zip local-file-header magic
+            # (e.g. a JSON error body) — not worth resuming, so the file is
+            # discarded and the next attempt starts a clean download.
+            # 3 = starts like a zip but has no end-of-central-directory
+            # record in the tail — a genuinely truncated transfer, safe to
+            # resume in place with -C -.
+            validate_nad_zip() {
+              node -e '
+                const fs = require("fs");
+                const p = process.argv[1];
+                let size;
+                try { size = fs.statSync(p).size; } catch { console.error("no file on disk"); process.exit(2); }
+                if (size === 0) { console.error("empty file"); process.exit(2); }
+                const fd = fs.openSync(p, "r");
+                const head = Buffer.alloc(Math.min(4, size));
+                fs.readSync(fd, head, 0, head.length, 0);
+                if (!head.equals(Buffer.from([0x50, 0x4b, 0x03, 0x04]))) {
+                  console.error("missing zip local-file-header magic (PK\\x03\\x04) at offset 0");
+                  fs.closeSync(fd);
+                  process.exit(2);
+                }
+                const tailLen = Math.min(65536, size);
+                const tail = Buffer.alloc(tailLen);
+                fs.readSync(fd, tail, 0, tailLen, size - tailLen);
+                fs.closeSync(fd);
+                if (tail.indexOf(Buffer.from([0x50, 0x4b, 0x05, 0x06])) === -1) {
+                  console.error("no end-of-central-directory signature (PK\\x05\\x06) in last " + tailLen + " bytes -- truncated transfer");
+                  process.exit(3);
+                }
+              ' "$1"
+            }
+
+            NAD_OK=0
+            for attempt in 1 2 3; do
+              echo "NAD download attempt $attempt/3..."
+              curl -sSL --retry 3 --retry-all-errors -C - -o "$NAD_ZIP" "$NAD_URL" \
+                || echo "curl exited non-zero on attempt $attempt (retries exhausted)"
+
+              set +e
+              VALIDATION_ERROR="$(validate_nad_zip "$NAD_ZIP" 2>&1 1>/dev/null)"
+              RC=$?
+              set -e
+
+              if [ "$RC" -eq 0 ]; then
+                NAD_OK=1
+                break
+              fi
+
+              echo "::warning::NAD download attempt $attempt/3 failed validation: $VALIDATION_ERROR"
+              SIZE=$(stat -c%s "$NAD_ZIP" 2>/dev/null || echo 0)
+              if [ "$SIZE" -gt 0 ] && [ "$SIZE" -lt 1048576 ]; then
+                echo "--- response body (first 300 bytes -- likely the upstream error, verbatim) ---"
+                head -c 300 "$NAD_ZIP" || true
+                echo
+                echo "--- end response body ---"
+              fi
+
+              # A non-zip body (RC=2) isn't worth resuming -- discard it so
+              # the next attempt starts a clean download instead of ranging
+              # on top of garbage. A truncated-but-real zip (RC=3) is kept
+              # so -C - can resume it.
+              if [ "$RC" -eq 2 ]; then
+                rm -f "$NAD_ZIP"
+              fi
+
+              if [ "$attempt" -lt 3 ]; then
+                sleep 90
+              fi
+            done
+
+            if [ "$NAD_OK" -ne 1 ]; then
+              echo "::error::NAD upstream served a non-zip body after 3 attempts — upstream outage; re-dispatch with nad_url= for a ranges-only publish, or retry later"
+              exit 1
+            fi
+
+            echo "- **NAD zip sha256 (computed):** $(sha256sum "$NAD_ZIP" | awk '{print $1}')" >> $GITHUB_STEP_SUMMARY
+
+            funzip < "$NAD_ZIP" \
               | npx tsx scripts/build-address-index.ts --nad - \
                   --nad-vintage "${{ inputs.nad_vintage || 'unknown' }}" \
                   "${ARGS[@]}"
-            echo "- **NAD zip sha256 (computed):** $(cat nad-download.sha256)" >> $GITHUB_STEP_SUMMARY
+
+            rm -f "$NAD_ZIP"
           else
             npx tsx scripts/build-address-index.ts "${ARGS[@]}"
           fi

--- a/packages/shadow-atlas/src/__tests__/unit/acquisition/source-prober.test.ts
+++ b/packages/shadow-atlas/src/__tests__/unit/acquisition/source-prober.test.ts
@@ -226,6 +226,66 @@ describe('source-prober', () => {
     expect(row?.last_error).toBeNull();
   });
 
+  it('200 with application/json content-type on an expectShape:"zip" row records a shape-mismatch failure', async () => {
+    const fetchImpl: FetchLike = vi.fn(async () => fakeResponse(200, { 'content-type': 'application/json' }));
+    const zipConfig = SOURCE_REGISTRY.find(r => r.id === 'nad')!;
+    expect(zipConfig.probe?.expectShape).toBe('zip');
+
+    await runProbeLane({ fetchImpl, store, now: fixedNow, fetchLaneSources: [] }, [zipConfig]);
+
+    const row = store.getRow('nad');
+    expect(row?.consecutive_failures).toBe(1);
+    expect(row?.last_error).toContain('shape mismatch');
+    expect(row?.last_error).toContain('expected zip');
+    expect(row?.last_error).toContain('application/json');
+  });
+
+  it('200 with a matching zip content-type counts as success on an expectShape:"zip" row', async () => {
+    const fetchImpl: FetchLike = vi.fn(async () => fakeResponse(200, { 'content-type': 'application/zip' }));
+    const zipConfig = SOURCE_REGISTRY.find(r => r.id === 'nad')!;
+
+    await runProbeLane({ fetchImpl, store, now: fixedNow, fetchLaneSources: [] }, [zipConfig]);
+
+    const row = store.getRow('nad');
+    expect(row?.consecutive_failures).toBe(0);
+    expect(row?.last_error).toBeNull();
+  });
+
+  it('a HEAD-only row (no range-GET fallback triggered) still honors Content-Type for its shape check', async () => {
+    const calls: Array<{ method?: string }> = [];
+    const fetchImpl: FetchLike = vi.fn(async (_url, init) => {
+      calls.push({ method: init?.method });
+      // 200 on the HEAD itself — no 405/501, so no range-GET fallback fires.
+      return fakeResponse(200, { 'content-type': 'application/json' });
+    });
+    const zipConfig = SOURCE_REGISTRY.find(r => r.id === 'bef-cd119')!;
+    expect(zipConfig.probe?.method).toBe('head');
+    expect(zipConfig.probe?.expectShape).toBe('zip');
+
+    await runProbeLane({ fetchImpl, store, now: fixedNow, fetchLaneSources: [] }, [zipConfig]);
+
+    // A shape mismatch is retried within the same backoff budget as any
+    // other failure (it's a 200, not a 405/501, so every retry is a HEAD —
+    // the range-GET fallback path never fires).
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every(c => c.method === 'HEAD')).toBe(true);
+    const row = store.getRow('bef-cd119');
+    expect(row?.consecutive_failures).toBe(1);
+    expect(row?.last_error).toContain('shape mismatch');
+  });
+
+  it('a row with no expectShape configured ignores Content-Type entirely (behavior unchanged)', async () => {
+    const fetchImpl: FetchLike = vi.fn(async () => fakeResponse(200, { 'content-type': 'text/html' }));
+    const noShapeConfig = SOURCE_REGISTRY.find(r => r.id === 'addrfeat')!;
+    expect(noShapeConfig.probe?.expectShape).toBeUndefined();
+
+    await runProbeLane({ fetchImpl, store, now: fixedNow, fetchLaneSources: [] }, [noShapeConfig]);
+
+    const row = store.getRow('addrfeat');
+    expect(row?.consecutive_failures).toBe(0);
+    expect(row?.last_error).toBeNull();
+  });
+
   it('vintage-row probe success does NOT stamp last_success_at', async () => {
     const fetchImpl: FetchLike = vi.fn(async () => fakeResponse(200));
     const vintageConfig = SOURCE_REGISTRY.find(r => r.id === 'nad')!; // freshness: 'vintage'

--- a/packages/shadow-atlas/src/acquisition/source-health.ts
+++ b/packages/shadow-atlas/src/acquisition/source-health.ts
@@ -52,6 +52,13 @@ export interface NextVintageProbeConfig {
   readonly windowMonths: readonly number[];
 }
 
+/** Expected content-shape of a healthy probe response. Lets the prober catch
+ *  a 2xx/304 response whose body isn't actually what it claims to be (the
+ *  motivating failure class: an upstream error page/API serving an HTTP-200
+ *  JSON body in place of the real zip/binary artifact — a status-only check
+ *  calls that "healthy"). */
+export type ProbeExpectShape = 'zip' | 'json' | 'xml';
+
 export interface SourceProbeConfig {
   /** First-choice probe method. The prober auto-falls-back HEAD -> range-GET
    *  (`Range: bytes=0-0`) on 405/501/hang regardless of this setting. */
@@ -65,6 +72,11 @@ export interface SourceProbeConfig {
   /** Vintage sources only: window-gated probe of the NEXT vintage URL,
    *  recorded on the derived `<id>@next-vintage` ledger row. */
   readonly nextVintage?: NextVintageProbeConfig;
+  /** When set, a 2xx/304 probe response whose Content-Type contradicts this
+   *  shape is recorded as a FAILURE (`shape mismatch: expected <shape>, got
+   *  <content-type>`) instead of a success — see source-prober.ts's shape
+   *  check. Optional: rows that omit it keep pure status-code semantics. */
+  readonly expectShape?: ProbeExpectShape;
 }
 
 export interface SourceHealthConfig {
@@ -260,7 +272,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'cd per BAF map',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-state-sldu',
@@ -275,7 +287,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'sldu per BAF map',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-state-sldl',
@@ -290,7 +302,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'sldl per BAF map',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-state-county',
@@ -305,7 +317,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'county per BAF map',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-place',
@@ -317,7 +329,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'place',
     lane: 'probe',
-    probe: { method: 'head' },
+    probe: { method: 'head', expectShape: 'zip' },
   },
   {
     id: 'tiger-tract-centroids',
@@ -329,6 +341,11 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'PIP substrate (all slots)',
     lane: 'probe',
+    // No expectShape here (unlike its zip-artifact siblings): the probe
+    // target is the TRACT/ directory-listing page itself (see
+    // resolveProbeUrl's directory-listing branch below), not an individual
+    // zip file — it genuinely serves text/html on a healthy day. Applying a
+    // zip shape check would flag every successful probe as a mismatch.
     probe: { method: 'head', sample: 'rotate-daily' },
   },
   {
@@ -341,7 +358,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'context + aiannh',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-national-cbsa',
@@ -353,7 +370,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'context + aiannh',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-national-state',
@@ -365,7 +382,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'context + aiannh',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-national-county',
@@ -377,7 +394,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'context + aiannh',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-national-zcta520',
@@ -389,7 +406,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'context + aiannh',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-national-uac',
@@ -401,7 +418,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'context + aiannh',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'tiger-national-mil',
@@ -413,7 +430,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'context + aiannh',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     id: 'bef-cd119',
@@ -425,7 +442,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'cd overlay',
     lane: 'probe',
-    probe: { method: 'head' },
+    probe: { method: 'head', expectShape: 'zip' },
   },
   {
     id: 'baf-2020',
@@ -443,7 +460,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'frozen',
     ownerSlots: 'slots 0-5, 7-9, 20-21 (jurisdiction.ts:262)',
     lane: 'probe',
-    probe: { method: 'head', sample: 'rotate-daily' },
+    probe: { method: 'head', sample: 'rotate-daily', expectShape: 'zip' },
   },
   {
     // Aggregate template row for the ward-arcgis family — NOT a real
@@ -485,6 +502,11 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'address src:1',
     lane: 'probe',
+    // No expectShape: like tiger-tract-centroids above, this row's probe
+    // target is the ADDRFEAT/ directory-listing page (resolveProbeUrl's
+    // directory-listing branch), which genuinely serves text/html on a
+    // healthy day — not the per-county zip files the family actually
+    // distributes. A zip shape check here would misfire on every success.
     probe: { method: 'get', sample: 'rotate-daily' },
   },
   {
@@ -501,7 +523,12 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: 'address src:0',
     lane: 'probe',
-    probe: { method: 'head' },
+    // expectShape: 'zip' catches the exact live failure class this source
+    // has produced — a 2xx response whose body is an upstream error
+    // page/API JSON blob, not the NAD zip. A HEAD probe checks Content-Type
+    // only (no body to inspect); the range-GET fallback path (405/501/hang)
+    // gets the same check on whatever bytes/headers it receives.
+    probe: { method: 'head', expectShape: 'zip' },
   },
   {
     id: 'congress-legislators-current',
@@ -532,7 +559,11 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'rolling',
     ownerSlots: 'CD geometry service',
     lane: 'probe',
-    probe: { method: 'get', url: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer/54?f=json' },
+    probe: {
+      method: 'get',
+      url: 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer/54?f=json',
+      expectShape: 'json',
+    },
   },
   {
     id: 'uk-mps',
@@ -809,7 +840,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: '21',
     lane: 'probe',
-    probe: { method: 'get' },
+    probe: { method: 'get', expectShape: 'json' },
   },
   {
     id: 'precinct-in',
@@ -828,6 +859,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     probe: {
       method: 'get',
       nextVintage: { template: 'Voting_District_Boundaries_{yyyy}', windowMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] },
+      expectShape: 'json',
     },
   },
   {
@@ -842,7 +874,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: '21',
     lane: 'probe',
-    probe: { method: 'get' },
+    probe: { method: 'get', expectShape: 'json' },
   },
   {
     id: 'precinct-md',
@@ -869,7 +901,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'rolling',
     ownerSlots: '21',
     lane: 'probe',
-    probe: { method: 'get' },
+    probe: { method: 'get', expectShape: 'json' },
   },
   {
     id: 'precinct-mi',
@@ -887,7 +919,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     lane: 'probe',
     // AGOL search JSON (owner:michigan_admin title:"Voting Precincts") --
     // picks up new cycle items rather than a pinned year (§4, verbatim).
-    probe: { method: 'get' },
+    probe: { method: 'get', expectShape: 'json' },
   },
   {
     id: 'precinct-mt',
@@ -937,7 +969,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'rolling',
     ownerSlots: '21',
     lane: 'probe',
-    probe: { method: 'get' },
+    probe: { method: 'get', expectShape: 'json' },
   },
   {
     id: 'precinct-nc',
@@ -986,7 +1018,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'vintage',
     ownerSlots: '21',
     lane: 'probe',
-    probe: { method: 'get' },
+    probe: { method: 'get', expectShape: 'json' },
   },
   {
     id: 'precinct-sc',
@@ -1059,6 +1091,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     probe: {
       method: 'get',
       nextVintage: { template: 'Statewide_Precincts_{yyyy}General.zip', windowMonths: [11, 12, 1] },
+      expectShape: 'json',
     },
   },
   {
@@ -1074,6 +1107,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     probe: {
       method: 'get',
       nextVintage: { template: 'LTSB hub new-cycle items', windowMonths: [2, 3, 8, 9] },
+      expectShape: 'json',
     },
   },
   {
@@ -1086,7 +1120,7 @@ export const SOURCE_REGISTRY: readonly SourceHealthConfig[] = [
     freshness: 'rolling',
     ownerSlots: '21',
     lane: 'probe',
-    probe: { method: 'get' },
+    probe: { method: 'get', expectShape: 'json' },
   },
 ];
 

--- a/packages/shadow-atlas/src/acquisition/source-prober.ts
+++ b/packages/shadow-atlas/src/acquisition/source-prober.ts
@@ -26,6 +26,7 @@ import {
   isWardArcgisFamilyUrl,
   PINNED_TIGER_VINTAGE,
   type SourceHealthConfig,
+  type ProbeExpectShape,
 } from './source-health.js';
 import { STATE_FIPS, buildBafUrl } from '../hydration/baf-downloader.js';
 import { buildTigerStateUrl } from './change-detection-adapter.js';
@@ -229,6 +230,34 @@ async function withTimeout<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<
 interface RawProbeResult {
   readonly status: number;
   readonly ok: boolean;
+  /** Raw `Content-Type` response header, or null when absent/unavailable
+   *  (e.g. a thrown network error never reaches a response at all). Read
+   *  regardless of probe method — HEAD responses carry headers same as
+   *  GET, just no body. */
+  readonly contentType: string | null;
+}
+
+/**
+ * Whether a Content-Type header is consistent with an `expectShape`
+ * declaration. Substring match against the shape's registered MIME
+ * fragment (e.g. "zip" matches "application/zip",
+ * "application/x-zip-compressed"; "json" matches
+ * "application/json;charset=UTF-8"). A missing/unparseable Content-Type is
+ * treated as "no contradiction" — this is a shape MISMATCH detector, not a
+ * shape-presence requirement, so silence is never itself a failure.
+ *
+ * Byte-level sniffing (the "first bytes when available" half of the
+ * design's check) is deliberately not implemented here: FetchLike is a
+ * reachability-only surface (see this module's header doc) that never
+ * exposes a response body, and every currently-wired expectShape row is
+ * fully decided by Content-Type alone (the incident this exists to catch
+ * — an HTTP-200 JSON error body in place of a zip — already changes
+ * Content-Type, not just body bytes).
+ */
+function contentTypeMatchesShape(contentType: string | null, shape: ProbeExpectShape): boolean {
+  if (!contentType) return true;
+  const lower = contentType.toLowerCase();
+  return lower.includes(shape);
 }
 
 /**
@@ -255,7 +284,7 @@ async function issueProbe(
       if (res.status === 405 || res.status === 501) {
         return rangeGetFallback(fetchImpl, url);
       }
-      return { status: res.status, ok: res.ok };
+      return { status: res.status, ok: res.ok, contentType: res.headers.get('content-type') };
     } catch {
       // Hang/abort/network error on HEAD — automatic range-GET fallback,
       // per the design ("on 405/501/hang").
@@ -269,14 +298,18 @@ async function issueProbe(
     const res = await withTimeout(signal =>
       fetchImpl(url, { method: 'GET', headers, signal: signal as AbortSignal })
     );
-    return { status: res.status, ok: res.ok || res.status === 304 };
+    return {
+      status: res.status,
+      ok: res.ok || res.status === 304,
+      contentType: res.headers.get('content-type'),
+    };
   }
 
   // 'get' — plain GET first-bytes for HEAD-hostile targets.
   const res = await withTimeout(signal =>
     fetchImpl(url, { method: 'GET', signal: signal as AbortSignal })
   );
-  return { status: res.status, ok: res.ok };
+  return { status: res.status, ok: res.ok, contentType: res.headers.get('content-type') };
 }
 
 async function rangeGetFallback(fetchImpl: FetchLike, url: string): Promise<RawProbeResult> {
@@ -284,7 +317,7 @@ async function rangeGetFallback(fetchImpl: FetchLike, url: string): Promise<RawP
     fetchImpl(url, { method: 'GET', headers: { Range: 'bytes=0-0' }, signal: signal as AbortSignal })
   );
   const ok = res.status === 206 || res.status === 200;
-  return { status: res.status, ok };
+  return { status: res.status, ok, contentType: res.headers.get('content-type') };
 }
 
 function isSuccessStatus(status: number): boolean {
@@ -294,7 +327,8 @@ function isSuccessStatus(status: number): boolean {
 async function probeWithBackoff(
   fetchImpl: FetchLike,
   url: string,
-  method: NonNullable<SourceHealthConfig['probe']>['method']
+  method: NonNullable<SourceHealthConfig['probe']>['method'],
+  expectShape?: ProbeExpectShape
 ): Promise<{ success: boolean; status?: number; error?: string }> {
   let delayMs = PROBE_BACKOFF_INITIAL_MS;
   let lastError: string | undefined;
@@ -303,9 +337,19 @@ async function probeWithBackoff(
     try {
       const result = await issueProbe(fetchImpl, url, method);
       if (isSuccessStatus(result.status)) {
-        return { success: true, status: result.status };
+        if (!expectShape || contentTypeMatchesShape(result.contentType, expectShape)) {
+          return { success: true, status: result.status };
+        }
+        // A 2xx/304 status is not "healthy" when the body isn't shaped
+        // like what this source is supposed to serve — the motivating
+        // case being an upstream error page/API returning HTTP 200 with a
+        // JSON body in place of the real zip artifact. Recorded exactly
+        // like any other probe failure (retried within budget, then
+        // advances consecutive_failures).
+        lastError = `shape mismatch: expected ${expectShape}, got ${result.contentType ?? 'unknown content-type'}`;
+      } else {
+        lastError = `HTTP ${result.status}`;
       }
-      lastError = `HTTP ${result.status}`;
       // 4xx/5xx are not retried further within one probe cycle if the
       // status is a definitive client/server error — but per the design's
       // "x3 backoff" posture we retry transient-looking failures uniformly,
@@ -414,7 +458,7 @@ export async function runProbeLane(
 
       const url = resolveNextVintageUrl(config, nowDate);
       const method = config.probe!.method;
-      const result = await probeWithBackoff(fetchImpl, url, method);
+      const result = await probeWithBackoff(fetchImpl, url, method, config.probe?.expectShape);
       const at = nowDate.toISOString();
 
       if (result.success) {
@@ -432,7 +476,7 @@ export async function runProbeLane(
 
     const url = resolveProbeUrl(config, nowDate);
     const method = config.probe!.method;
-    const result = await probeWithBackoff(fetchImpl, url, method);
+    const result = await probeWithBackoff(fetchImpl, url, method, config.probe?.expectShape);
     const at = nowDate.toISOString();
 
     if (result.success) {


### PR DESCRIPTION
Hardens the two seams the live NAD upstream outage exposed (DOT/Socrata serving a 200 JSON 'Internal error' body instead of the release zip):

1. Quarterly Build Address Index: pre-download with resumable retries + zip-magic/EOCD validation before funzip; non-zip bodies discarded (never resumed onto); small error bodies printed verbatim; 3-strikes failure message names the `nad_url=` ranges-only workaround.
2. Probe lane: `expectShape` on probe configs — a 200 with contradicting Content-Type now advances failure counters instead of masquerading as healthy.

Adversarially reviewed; the workflow reviewer executed the extracted step body under shimmed bash across 6 scenarios (json-body, 2MB non-zip, truncate-then-resume, perpetual truncation, curl failure, empty nad_url) — all byte-exact. 74/74 changed-scope tests, tsc clean, actionlint 0 new findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added response-shape checks for source probes, helping validate ZIP, JSON, and XML downloads more accurately.
  * Expanded address-index processing to verify downloaded archives before use and retry interrupted transfers.

* **Bug Fixes**
  * Prevents false successes when a download returns the wrong content type.
  * Improves handling of truncated or invalid downloads by discarding bad responses and retrying safely.
  * Added tests covering the new probe validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->