### PR TITLE
Default nad_url empty (ranges-only) — NAD opt-in during DOT outage

### DIFF
--- a/.github/workflows/shadow-atlas-quarterly.yml
+++ b/.github/workflows/shadow-atlas-quarterly.yml
@@ -76,10 +76,10 @@ on:
         type: string
         default: 'unknown'
       nad_url:
-        description: 'NAD text-release zip URL (streamed through funzip, never stored on disk). Empty skips NAD (src:0) and builds a ranges-only index.'
+        description: 'NAD text-release zip URL (streamed through funzip, never stored on disk). Empty (default) skips NAD (src:0) and builds a robust ranges-only index; pass the DOT release URL only when that upstream is healthy. Default was the DOT URL until its service outage made a fragile external the publish default.'
         required: false
         type: string
-        default: 'https://data.transportation.gov/download/fc2s-wawr/application/x-zip-compressed'
+        default: ''
       address_states:
         description: 'CSV of states for the address index (e.g. DE,RI,DC). Empty = all states.'
         required: false


### PR DESCRIPTION
The DOT NAD endpoint is returning HTTP 500 (JSON error body, not the zip). With nad_url defaulting to it, the publish streams a broken external and dies at funzip; `-f nad_url=` empty falls back to the default (GitHub quirk). Default to '' so a plain dispatch ships the ranges-only index (flips boundaryAsOf/officialsAsOf/addressIndexGenerated with honest nadVintage:null). Pass the DOT URL explicitly when it recovers. yaml validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the quarterly publish workflow so it now skips NAD by default unless a NAD URL is provided.
  * Clarified the workflow input description to reflect the new default behavior and the resulting ranges-only index output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->