### PR TITLE
Complete v2 shard contract — coherent chunk-index + per-shard integrity pins

### DIFF
--- a/packages/shadow-atlas/scripts/validate-build.ts
+++ b/packages/shadow-atlas/scripts/validate-build.ts
@@ -33,6 +33,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { cellToParent } from 'h3-js';
 import {
   US_JURISDICTION,
@@ -105,7 +106,7 @@ interface ManifestFile {
   addressIndex?: AddressIndexSection;
 }
 
-/** manifest.addressIndex — SEAM-CONTRACT v1 (atlas-address-index) §4. */
+/** manifest.addressIndex — SEAM-CONTRACT atlas-address-index §4. */
 interface AddressIndexSection {
   schemaVersion: number;
   normVersion: number;
@@ -125,6 +126,12 @@ type AddressChunkIndex = Record<
   string,
   { streetCount: number; bytes: number; sha256: string }
 >;
+
+interface AddressChunkStubV2 {
+  v: 2;
+  shards: number;
+  shardHashes: { bytes: number; sha256: string }[];
+}
 
 interface ChunkManifestEntry {
   path: string;
@@ -1008,7 +1015,7 @@ const ADDRESS_HASH_SPOT_LIMIT = 500;
  * A manifest WITHOUT an addressIndex section is a boundary-only build — the
  * check warns (and fails under --strict) instead of failing outright.
  */
-function checkAddressIndex(
+export function checkAddressIndex(
   outputDir: string,
   country: string,
   manifest: ManifestFile,
@@ -1028,8 +1035,8 @@ function checkAddressIndex(
   const failures: string[] = [];
 
   // --- Section fields ---
-  if (ai.schemaVersion !== 1) {
-    failures.push(`addressIndex.schemaVersion=${ai.schemaVersion}, expected 1`);
+  if (ai.schemaVersion !== 1 && ai.schemaVersion !== 2) {
+    failures.push(`addressIndex.schemaVersion=${ai.schemaVersion}, expected 1 or 2`);
   }
   if (ai.normVersion !== 1) {
     failures.push(`addressIndex.normVersion=${ai.normVersion}, expected 1`);
@@ -1152,14 +1159,78 @@ function checkAddressIndex(
         bytesVerified++;
 
         const spotCheck = i % hashStride === 0 || i === entries.length - 1;
+        let chunkBuf: Buffer | null = null;
         if (spotCheck) {
-          const actualHash = createHash('sha256').update(readFileSync(chunkPath)).digest('hex');
+          chunkBuf = readFileSync(chunkPath);
+          const actualHash = createHash('sha256').update(chunkBuf).digest('hex');
           if (actualHash !== entry.sha256) {
             failures.push(
               `addresses/${zip}.json: sha256 mismatch (expected ${entry.sha256.slice(0, 12)}..., got ${actualHash.slice(0, 12)}...)`,
             );
           } else {
             hashesVerified++;
+          }
+        }
+
+        let parsedChunk: unknown = null;
+        try {
+          chunkBuf ??= readFileSync(chunkPath);
+          parsedChunk = JSON.parse(chunkBuf.toString('utf-8'));
+        } catch (err) {
+          failures.push(`addresses/${zip}.json: invalid JSON — ${(err as Error).message}`);
+          if (failures.length >= 50) break;
+          continue;
+        }
+
+        if (
+          parsedChunk &&
+          typeof parsedChunk === 'object' &&
+          (parsedChunk as { v?: unknown }).v === 2
+        ) {
+          const stub = parsedChunk as Partial<AddressChunkStubV2>;
+          if (typeof stub.shards !== 'number' || !Number.isInteger(stub.shards) || stub.shards < 0) {
+            failures.push(`addresses/${zip}.json: v2 stub has invalid shards=${JSON.stringify(stub.shards)}`);
+          } else if (!Array.isArray(stub.shardHashes)) {
+            failures.push(`addresses/${zip}.json: v2 stub missing shardHashes`);
+          } else {
+            if (stub.shardHashes.length !== stub.shards) {
+              failures.push(
+                `addresses/${zip}.json: shardHashes has ${stub.shardHashes.length} entries, stub shards=${stub.shards}`,
+              );
+            }
+            for (let shard = 0; shard < stub.shards; shard++) {
+              const pin = stub.shardHashes[shard];
+              if (!pin || typeof pin.bytes !== 'number' || typeof pin.sha256 !== 'string') {
+                failures.push(`addresses/${zip}.${shard}.json: missing bytes/sha256 in stub shardHashes`);
+                if (failures.length >= 50) break;
+                continue;
+              }
+              const shardPath = join(countryRoot, 'addresses', `${zip}.${shard}.json`);
+              if (!existsSync(shardPath)) {
+                failures.push(`shard missing on disk: addresses/${zip}.${shard}.json`);
+                if (failures.length >= 50) break;
+                continue;
+              }
+              const shardStat = statSync(shardPath);
+              if (shardStat.size !== pin.bytes) {
+                failures.push(
+                  `addresses/${zip}.${shard}.json: ${shardStat.size} bytes on disk, stub pins ${pin.bytes}`,
+                );
+                if (failures.length >= 50) break;
+                continue;
+              }
+              if (spotCheck) {
+                const actualShardHash = createHash('sha256').update(readFileSync(shardPath)).digest('hex');
+                if (actualShardHash !== pin.sha256) {
+                  failures.push(
+                    `addresses/${zip}.${shard}.json: sha256 mismatch (expected ${pin.sha256.slice(0, 12)}..., got ${actualShardHash.slice(0, 12)}...)`,
+                  );
+                } else {
+                  hashesVerified++;
+                }
+              }
+              if (failures.length >= 50) break;
+            }
           }
         }
 
@@ -1399,4 +1470,10 @@ function main(): void {
   process.exit(passed ? 0 : 1);
 }
 
-main();
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (invokedDirectly) {
+  main();
+}

--- a/packages/shadow-atlas/scripts/verify-address-assertions.ts
+++ b/packages/shadow-atlas/scripts/verify-address-assertions.ts
@@ -425,8 +425,8 @@ function main(): void {
   if (!ai) {
     integrityFailures.push('US/manifest.json has no addressIndex section');
   } else {
-    if (ai.schemaVersion !== 1) {
-      integrityFailures.push(`manifest addressIndex.schemaVersion=${ai.schemaVersion}, expected 1`);
+    if (ai.schemaVersion !== 1 && ai.schemaVersion !== 2) {
+      integrityFailures.push(`manifest addressIndex.schemaVersion=${ai.schemaVersion}, expected 1 or 2`);
     }
     if (ai.normVersion !== corpus.normVersion) {
       integrityFailures.push(

--- a/packages/shadow-atlas/src/__tests__/unit/address-index/chunk-split.test.ts
+++ b/packages/shadow-atlas/src/__tests__/unit/address-index/chunk-split.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -78,10 +79,17 @@ describe('oversized ZIP5 split (§1 v2)', () => {
     expect(stub.shards).toBe(shards);
     expect(shards).toBeGreaterThanOrEqual(2);
     expect(shardArtifacts.length).toBe(shards);
+    expect(stub.shardHashes).toHaveLength(shards);
 
     const target = CHUNK_P95_LIMIT_BYTES / 1.3; // §1 headroom
-    for (const artifact of shardArtifacts) {
+    for (let i = 0; i < shardArtifacts.length; i++) {
+      const artifact = shardArtifacts[i];
       expect(artifact.bytes).toBeLessThanOrEqual(target);
+      const shardBuf = readFileSync(join(outDir, `94999.${i}.json`));
+      expect(stub.shardHashes[i]).toEqual({
+        bytes: shardBuf.length,
+        sha256: createHash('sha256').update(shardBuf).digest('hex'),
+      });
     }
 
     // The guard itself, run over every emitted file, passes.
@@ -246,6 +254,25 @@ describe('oversized ZIP5 split (§1 v2)', () => {
     expect(written.version).toBe(1);
     expect(written.v).toBeUndefined();
     expect(written.shards).toBeUndefined();
+  });
+
+  it('writeChunkFileAutoSplit pins the split stub in chunk-index and keeps all emitted file sizes for the guard', () => {
+    const chunk = buildOversizedChunk('94999', 800, 40);
+    const result = writeChunkFileAutoSplit(outDir, chunk);
+    const stubBuf = readFileSync(join(outDir, '94999.json'));
+    const stub: AddressChunkStubV2 = JSON.parse(stubBuf.toString('utf-8'));
+    const shardSizes = Array.from({ length: stub.shards }, (_, i) => statSync(join(outDir, `94999.${i}.json`)).size);
+
+    expect(result.entry.bytes).toBe(stubBuf.length);
+    expect(result.entry.sha256).toBe(createHash('sha256').update(stubBuf).digest('hex'));
+    expect(result.entry.bytes).toBeLessThan(Math.max(...shardSizes));
+    expect(result.emittedFileBytes).toEqual([stubBuf.length, ...shardSizes]);
+    expect(stub.shardHashes).toEqual(
+      shardSizes.map((bytes, i) => {
+        const shardBuf = readFileSync(join(outDir, `94999.${i}.json`));
+        return { bytes, sha256: createHash('sha256').update(shardBuf).digest('hex') };
+      })
+    );
   });
 
   it('consumer resolves a street from a sharded ZIP via the shared vectors', () => {

--- a/packages/shadow-atlas/src/__tests__/unit/address-index/validate-build-address-v2.test.ts
+++ b/packages/shadow-atlas/src/__tests__/unit/address-index/validate-build-address-v2.test.ts
@@ -1,0 +1,112 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { checkAddressIndex } from '../../../../scripts/validate-build.js';
+
+function sha256(buf: Buffer): string {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+function writeJson(path: string, value: unknown): { bytes: number; sha256: string } {
+  const buf = Buffer.from(JSON.stringify(value), 'utf-8');
+  writeFileSync(path, buf);
+  return { bytes: buf.length, sha256: sha256(buf) };
+}
+
+describe('validate-build address index v2 shard integrity', () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = mkdtempSync(join(tmpdir(), 'validate-address-v2-'));
+    mkdirSync(join(outputDir, 'US', 'addresses'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  function writeFixture(tamperShardHash = false): Record<string, unknown> {
+    const addressesDir = join(outputDir, 'US', 'addresses');
+    const shard = {
+      v: 2,
+      zip: '94999',
+      shard: 0,
+      shards: 1,
+      streets: {
+        'MAIN ST': { points: [['1', 37.7, -122.4, 0, 'CA']], ranges: [] },
+      },
+    };
+    const shardArtifact = writeJson(join(addressesDir, '94999.0.json'), shard);
+    const stub = {
+      v: 2,
+      schema: 'atlas-address-index',
+      country: 'US',
+      zip: '94999',
+      state: 'CA',
+      zipCentroid: [37.7, -122.4],
+      shards: 1,
+      shardHashes: [
+        {
+          bytes: shardArtifact.bytes,
+          sha256: tamperShardHash ? '0'.repeat(64) : shardArtifact.sha256,
+        },
+      ],
+    };
+    const stubArtifact = writeJson(join(addressesDir, '94999.json'), stub);
+    const chunkIndexArtifact = writeJson(join(addressesDir, 'chunk-index.json'), {
+      '94999': { streetCount: 1, bytes: stubArtifact.bytes, sha256: stubArtifact.sha256 },
+    });
+    const normArtifact = writeJson(join(addressesDir, 'normalization.json'), { normVersion: 1 });
+
+    return {
+      version: 1,
+      generated: '2026-01-01T00:00:00.000Z',
+      country: 'US',
+      totalCells: 0,
+      totalChunks: 0,
+      resolution: 7,
+      slotNames: {},
+      chunks: {},
+      addressIndexGenerated: '2026-01-01T00:00:00.000Z',
+      addressIndexVersion: 1,
+      addressIndex: {
+        schemaVersion: 2,
+        normVersion: 1,
+        normTable: { path: 'addresses/normalization.json', ...normArtifact },
+        nadVintage: null,
+        addrfeatVintage: null,
+        totalChunks: 1,
+        totalStreets: 1,
+        totalPoints: 1,
+        totalRanges: 0,
+        chunkIndex: { path: 'addresses/chunk-index.json', ...chunkIndexArtifact },
+      },
+    };
+  }
+
+  it('passes on coherent v2 stub and shard pins', () => {
+    const manifest = writeFixture();
+    const result = checkAddressIndex(outputDir, 'US', manifest as never);
+
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('addressIndex valid');
+    const chunkIndex = JSON.parse(readFileSync(join(outputDir, 'US', 'addresses', 'chunk-index.json'), 'utf-8')) as {
+      '94999': { bytes: number };
+    };
+    expect(readFileSync(join(outputDir, 'US', 'addresses', '94999.json')).length).toBe(
+      chunkIndex['94999'].bytes
+    );
+  });
+
+  it('fails when a v2 shard hash does not match the stub pin', () => {
+    const manifest = writeFixture(true);
+    const result = checkAddressIndex(outputDir, 'US', manifest as never);
+
+    expect(result.status).toBe('fail');
+    expect((result.details?.failures as string[]).some((f) => f.includes('addresses/94999.0.json: sha256 mismatch'))).toBe(
+      true
+    );
+  });
+});

--- a/packages/shadow-atlas/src/distribution/addresses/chunk-emit.ts
+++ b/packages/shadow-atlas/src/distribution/addresses/chunk-emit.ts
@@ -368,6 +368,8 @@ export interface AddressChunkStubV2 {
   state: string;
   zipCentroid: [number, number];
   shards: number;
+  /** Integrity pins for `addresses/{zip5}.{i}.json`; array index is the shard number. */
+  shardHashes: { bytes: number; sha256: string }[];
 }
 
 /** One shard file at `addresses/{zip5}.{shard}.json` — the streets subset only. */
@@ -527,6 +529,7 @@ export function splitOversizedChunk(
     state: chunk.state,
     zipCentroid: chunk.zipCentroid,
     shards,
+    shardHashes: shardArtifacts.map((a) => ({ bytes: a.bytes, sha256: a.sha256 })),
   };
   const stubBuf = Buffer.from(JSON.stringify(stub), 'utf-8');
   writeFileSync(join(addressesDir, `${chunk.zip}.json`), stubBuf);
@@ -570,7 +573,7 @@ export function writeChunkFileAutoSplit(
   const stubBuf = Buffer.from(JSON.stringify(stub), 'utf-8');
   const entry: ChunkIndexEntry = {
     streetCount: Object.keys(chunk.streets).length,
-    bytes: Math.max(stubBuf.length, ...shardArtifacts.map((a) => a.bytes)),
+    bytes: stubBuf.length,
     sha256: createHash('sha256').update(stubBuf).digest('hex'),
   };
   return {


### PR DESCRIPTION
Unblocks the publish: the ranges-only national build cleared Build Address Index (the 5-attempt blocker) but failed Validate Build because P20's shard-split left the v2 contract incomplete — the chunk-index entry described two different files for split ZIPs, and shard files had zero integrity pinning under the signed manifest.

- chunk-index entry.bytes = stub file size (coherent with its stub sha256)
- AddressChunkStubV2 gains shardHashes[{bytes,sha256}] (producer already computed them); shards are now verifiable
- validate-build.ts + verify-address-assertions.ts accept schemaVersion 1|2 and verify every shard (exists, size, sha) — new test proves a tampered shard fails
- size-guard emittedFileBytes untouched; determinism preserved (double-emit byte-identical)

93 tests + tsc clean. Adversarially reviewed (2 lenses, 0 refutations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for larger address data files, including split-file integrity tracking.
  * Added stronger validation for newer address file format versions.

* **Bug Fixes**
  * Fixed address build validation to correctly handle split shard files and verify their size and contents.
  * Updated integrity checks so valid newer-format data no longer fails schema/version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->