### PR TITLE
fix(shadow-atlas): correct the street-shard hash invariant + pin non-ASCII vectors

### DIFF
--- a/packages/shadow-atlas/src/distribution/addresses/shared-vectors/stable-street-shard.vectors.json
+++ b/packages/shadow-atlas/src/distribution/addresses/shared-vectors/stable-street-shard.vectors.json
@@ -375,6 +375,106 @@
       "streetKey": "WASHINGTON ST",
       "shards": 32,
       "shard": 6
+    },
+    {
+      "streetKey": "ŁÓDŹ ST",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "ŁÓDŹ ST",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "ŁÓDŹ ST",
+      "shards": 8,
+      "shard": 5
+    },
+    {
+      "streetKey": "ŁÓDŹ ST",
+      "shards": 16,
+      "shard": 5
+    },
+    {
+      "streetKey": "ØSTER AVE",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "ØSTER AVE",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "ØSTER AVE",
+      "shards": 8,
+      "shard": 1
+    },
+    {
+      "streetKey": "ØSTER AVE",
+      "shards": 16,
+      "shard": 9
+    },
+    {
+      "streetKey": "STRAßE WEG",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "STRAßE WEG",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "STRAßE WEG",
+      "shards": 8,
+      "shard": 6
+    },
+    {
+      "streetKey": "STRAßE WEG",
+      "shards": 16,
+      "shard": 14
+    },
+    {
+      "streetKey": "CAFÉ BLVD",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "CAFÉ BLVD",
+      "shards": 4,
+      "shard": 0
+    },
+    {
+      "streetKey": "CAFÉ BLVD",
+      "shards": 8,
+      "shard": 0
+    },
+    {
+      "streetKey": "CAFÉ BLVD",
+      "shards": 16,
+      "shard": 0
+    },
+    {
+      "streetKey": "ÑU LN",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "ÑU LN",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "ÑU LN",
+      "shards": 8,
+      "shard": 3
+    },
+    {
+      "streetKey": "ÑU LN",
+      "shards": 16,
+      "shard": 11
     }
   ]
 }

--- a/packages/shadow-atlas/src/distribution/addresses/street-shard.ts
+++ b/packages/shadow-atlas/src/distribution/addresses/street-shard.ts
@@ -31,10 +31,13 @@
 
 /**
  * FNV-1a 32-bit hash of a UTF-16 string, taken code-unit-by-code-unit (NOT
- * UTF-8 byte-by-byte). Normalized street keys are pure ASCII by construction
- * (§3 step 1 uppercases and strips combining marks), so UTF-16 code units and
- * UTF-8 bytes coincide for every real input — this is a plain, dependency-free
- * 32-bit computation identical on both sides regardless of JS engine.
+ * UTF-8 byte-by-byte). The cross-repo invariant is NOT "inputs are ASCII"
+ * (§3 normalization strips combining marks but keeps non-decomposing
+ * letters like Ł or Ø): it is that BOTH sides run this exact code-unit
+ * computation — identical for every string, ASCII or not, on any JS engine
+ * (Math.imul is exact 32-bit). The shared vectors file pins this with
+ * non-ASCII cases; a reimplementation over UTF-8 bytes fails those vectors
+ * loudly instead of silently routing resolves to the wrong shard.
  */
 export function fnv1a32(input: string): number {
   let hash = 0x811c9dc5; // FNV offset basis (32-bit)


### PR DESCRIPTION
Mirror of the consumer-side fix in communisaas/commons#72 (review finding):

- The `fnv1a32` doc comment asserted normalized street keys are 'pure ASCII by construction'. That's false — §3 normalization strips combining marks but keeps non-decomposing letters (Ł, Ø, ß). The comment now states the actual invariant: **both repos run the identical UTF-16 code-unit computation**, identical for every string on any JS engine.
- 20 non-ASCII vectors appended to `stable-street-shard.vectors.json`, **byte-identical** with the commons copy (verified by diff), so any reimplementation over UTF-8 bytes fails the vector suite loudly instead of silently routing resolves to the wrong shard.

Producer chunk-split suite: 10/10 green with the new vectors.