### PR TITLE
fix(ci): stream the NAD release with unzip -p — funzip chokes on ZIP64

### DIFF
--- a/.github/workflows/shadow-atlas-quarterly.yml
+++ b/.github/workflows/shadow-atlas-quarterly.yml
@@ -807,8 +807,8 @@ jobs:
             #
             # Disk math: the ~7.6 GB zip plus the ~2.8 GB ADDRFEAT cache
             # fit comfortably within ubuntu-latest's free disk. The ~30 GB
-            # uncompressed NAD text still never touches disk — funzip
-            # streams it straight into the build below, exactly as before.
+            # uncompressed NAD text still never touches disk — unzip -p
+            # streams it straight into the build below.
             NAD_ZIP="data/nad-release.zip"
             rm -f "$NAD_ZIP"
 
@@ -890,7 +890,16 @@ jobs:
 
             echo "- **NAD zip sha256 (computed):** $(sha256sum "$NAD_ZIP" | awk '{print $1}')" >> $GITHUB_STEP_SUMMARY
 
-            funzip < "$NAD_ZIP" \
+            # The NAD release is ZIP64 (version-needed 45: its single member
+            # exceeds 4 GiB). funzip's 32-bit length bookkeeping exits 4
+            # AFTER streaming the whole member byte-perfectly, which under
+            # pipefail fails the step even when the build succeeded. unzip
+            # 6.0 reads the central directory (the zip is on disk anyway)
+            # and streams ZIP64 members correctly. The first member is named
+            # explicitly to preserve funzip's first-member-only semantics.
+            NAD_MEMBER="$(unzip -Z1 "$NAD_ZIP" | head -n 1)"
+            echo "NAD member: $NAD_MEMBER"
+            unzip -p "$NAD_ZIP" "$NAD_MEMBER" \
               | npx tsx scripts/build-address-index.ts --nad - \
                   --nad-vintage "${{ inputs.nad_vintage || 'unknown' }}" \
                   "${ARGS[@]}"


### PR DESCRIPTION
## Root cause

Run 28863527264 failed at **Build Address Index → exit 4** — but the build itself fully succeeded (79,111,383 NAD points ingested, 38,059 chunks, size guard OK, manifest merged, `Done.` printed). Under `set -o pipefail`, the 4 came from **funzip**, the left side of the pipe.

The NAD release is **ZIP64** (local header `504b0304 2d00` — version-needed 45; its single member is ~30 GB uncompressed). funzip's 32-bit length bookkeeping errors with `invalid compressed data--length error` (exit 4) **after streaming the entire member byte-perfectly**.

**Reproduced locally**: a 5 GiB ZIP64 archive → funzip streams all 5,242,880,000 bytes correctly, then exits 4. `unzip -p` on the same archive: identical bytes, exit 0.

**Why latent**: every earlier NAD-included attempt failed *inside* the build script first, and pipefail reports the rightmost non-zero exit — funzip's failure only became observable once the build finally exited 0.

## Fix

`unzip -p "$NAD_ZIP" "$NAD_MEMBER"` (first member listed explicitly via `unzip -Z1`, preserving funzip's first-member-only semantics). unzip 6.0 reads the central directory — the zip is already downloaded to disk for pre-validation — and handles ZIP64 correctly. The ~30 GB uncompressed text still never touches disk.

Fail-closed properties preserved: a truncated/corrupt stream still fails the pipe; the pre-download zip validation (magic + EOCD) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of larger archive files during address index builds, making quarterly updates more reliable.
  * Clarified archive processing behavior so the build uses the expected content consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->