### PR TITLE
fix(ci): give the R2 upload job headroom for the NAD-sized artifact

### DIFF
--- a/.github/workflows/shadow-atlas-quarterly.yml
+++ b/.github/workflows/shadow-atlas-quarterly.yml
@@ -995,7 +995,11 @@ jobs:
   upload-r2:
     name: Upload to R2
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The timeout covers the WHOLE job (npm ci + multi-GB artifact download
+    # + upload + S3 verification). The address index with NAD points pushed
+    # the upload past the old 30-minute ceiling (the ranges-only build took
+    # ~17 min end-to-end); 90 gives the bigger artifact honest headroom.
+    timeout-minutes: 90
     needs: [resolve-source, validate-build]
     outputs:
       atlas_base_url: ${{ steps.upload.outputs.atlas_base_url }}
@@ -1032,6 +1036,9 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET_NAME: shadow-atlas
           R2_PUBLIC_URL: https://atlas.commons.email
+          # I/O-bound PUTs against R2; the default 16 was sized for the
+          # pre-address-index artifact. 48 stays under the script's 64 cap.
+          UPLOAD_CONCURRENCY: '48'
         run: |
           npx tsx scripts/upload-to-r2.ts \
             --directory output/chunked/ \


### PR DESCRIPTION
Run 28884274850: the ZIP64 streaming fix (#148) worked — **Build Address Index and Validate Build both succeeded** with 79M NAD points — but **Upload to R2 hit the job's 30-minute timeout** (GitHub reports it as 'cancelled') at exactly 30:17 of job time.

The 30-minute ceiling was sized for the ranges-only artifact, whose upload took ~17 min end-to-end. The NAD artifact is substantially bigger: 38,059 chunks (5,278 split into shard files) + 79M points of payload, and the timeout also covers npm ci + the multi-GB artifact download.

- `timeout-minutes: 30 → 90`
- `UPLOAD_CONCURRENCY: 48` (default 16, script cap 64; PUTs are I/O-bound)

The uploader's fail-closed semantics are untouched — abort on first failure, no partial-upload acceptance, post-upload S3 verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the time allowed for a quarterly upload job so larger uploads can complete reliably.
  * Set a fixed upload concurrency limit to help prevent failures during the upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->