### PR TITLE
fix(ci): authenticate the diagnosis agent with the provisioned OAuth token

### DIFF
--- a/.github/workflows/shadow-atlas-remediate.yml
+++ b/.github/workflows/shadow-atlas-remediate.yml
@@ -247,7 +247,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           prompt: ${{ steps.contract.outputs.prompt }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
           claude_args: |
             --allowedTools "Read,Grep,Glob,Bash(curl -I *),Bash(gh issue comment *)"
@@ -438,7 +438,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           prompt: ${{ steps.contract.outputs.prompt }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
           claude_args: |
             --allowedTools "Read,Grep,Glob,Edit,Write,Bash(git checkout -b remediate/*),Bash(git add *),Bash(git commit *),Bash(git push origin remediate/*),Bash(gh issue comment *),Bash(gh issue edit *)"


### PR DESCRIPTION
The self-healing lane's plumbing has been proven live: the daily probe detected 4 real freshness breaches (#138, #140, #141, #154) and dispatched per-source Diagnose jobs — which all died at claude-code-action env validation because `secrets.ANTHROPIC_API_KEY` was never provisioned.

A `CLAUDE_CODE_OAUTH_TOKEN` repo secret is now provisioned (operator-supplied). OAuth tokens go to the action's `claude_code_oauth_token` input, not `anthropic_api_key` — both invocations updated.

Verification after merge: dispatch `shadow-atlas-change-check.yml` and confirm a diagnosis comment lands on the open breach issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the authentication method used by an automation workflow.
  * No user-facing behavior, permissions, or workflow outcomes were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->